### PR TITLE
feat(dev): add web UI and dev API for interactive runs

### DIFF
--- a/.crawlsnaprc.example.json
+++ b/.crawlsnaprc.example.json
@@ -10,5 +10,9 @@
   "continueOnError": true,
   "desktop": false,
   "mobile": false,
-  "excludePatterns": ["*/admin/*", "*/login/*"]
+  "excludePatterns": ["*/admin/*", "*/login/*"],
+  "includePatterns": ["*/products/*"],
+  "waitUntil": "networkidle",
+  "delay": 0,
+  "fullPage": true
 }

--- a/.crawlsnaprc.example.json
+++ b/.crawlsnaprc.example.json
@@ -1,0 +1,14 @@
+{
+  "resolutions": ["1920x1080", "1366x768", "390x844"],
+  "browser": "chromium",
+  "output": "./screenshots",
+  "crawl": false,
+  "maxPages": 50,
+  "timeout": 5000,
+  "concurrency": 3,
+  "retries": 2,
+  "continueOnError": true,
+  "desktop": false,
+  "mobile": false,
+  "excludePatterns": ["*/admin/*", "*/login/*"]
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,7 @@
 {
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
-  "extends": [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended"
-  ],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   "parserOptions": {
     "ecmaVersion": 2020,
     "sourceType": "module"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,16 @@ jobs:
         with:
           version: 8
 
-      - name: Install dependencies
+      - name: Install dependencies (root)
         run: pnpm install
 
-      - name: Build
+      - name: Install dependencies (ui)
+        run: pnpm -C ui install
+
+      - name: Build UI
+        run: pnpm -C ui build
+
+      - name: Build CLI
         run: pnpm run build
 
       - name: Run tests
@@ -48,8 +54,11 @@ jobs:
         with:
           version: 8
 
-      - name: Install dependencies
+      - name: Install dependencies (root)
         run: pnpm install
+
+      - name: Install dependencies (ui)
+        run: pnpm -C ui install
 
       - name: Lint
         run: pnpm run lint

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,7 +2,7 @@ name: Publish to npm
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
   workflow_dispatch:
 
 jobs:
@@ -14,18 +14,18 @@ jobs:
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
-      
+
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
           version: 8
-      
+
       - name: Install dependencies
         run: pnpm install
-      
+
       - name: Build
         run: pnpm run build
-        
+
       - name: Publish to npm
         run: pnpm publish --no-git-checks
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,11 @@ node_modules/
 
 # Build outputs
 dist/
+ui/dist/
 
 # Generated files
 generated-screenshots/
+dev-screenshots/
 
 # Environment variables
 .env

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,3 @@ coverage/
 node_modules/
 package-lock.json
 pnpm-lock.yaml
-
-# Ignore markdown
-*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
+
 - `src/`: TypeScript sources and colocated tests (`*.test.ts`).
 - `dist/`: Compiled JS and types (`tsc` output). Do not edit.
 - `static/`: Static assets (icons, images).
@@ -9,6 +10,7 @@
 - Config file example: `.crawlsnaprc.example.json` (users may copy to `.crawlsnaprc.json`).
 
 ## Build, Test, and Development Commands
+
 - `npm run dev` or `pnpm dev`: Run in watch mode with tsx. Pass CLI args after `--`.
   Example: `pnpm dev -- https://example.com --desktop`.
 - `npm run build` or `pnpm build`: Type-check and compile to `dist/`.
@@ -16,26 +18,31 @@
 - `npm test` / `pnpm test`: Run unit tests (Vitest).
 - `pnpm test:watch`: Watch mode for tests.
 - `npm run lint` / `pnpm lint`: ESLint checks. `lint:fix` to autofix.
-- `npm run format`: Prettier formatting (Markdown is ignored by default).
+- `npm run format`: Prettier formatting (includes Markdown).
 - First-time Playwright setup: `npx playwright install` (or `pnpx playwright install`).
 
 ## Coding Style & Naming Conventions
+
 - Language: TypeScript (Node >= 20).
 - Indentation: 2 spaces; single quotes; semicolons; width 100 (Prettier enforced).
 - File names: kebab-case for files, `*.test.ts` for tests colocated with sources.
 - Linting: ESLint with `@typescript-eslint` (see `eslint.config.mjs`). Fix warnings before PRs.
 
 ## Testing Guidelines
+
 - Framework: Vitest with V8 coverage (`text`, `lcov`, `html`).
 - Location: tests live next to code in `src/` and end with `.test.ts`.
 - Run: `pnpm test` (or `npm test`). Coverage reports emit to `coverage/`.
 
 ## Commit & Pull Request Guidelines
-- Commits: short, imperative subject; reference PRs/issues when relevant (e.g., "Fix badges (#3)").
-- Scope small; keep changes focused. Update `README.md` and `.crawlsnaprc.example.json` when flags/options change.
-- PRs: include description, rationale, before/after if behavior changes, test coverage, and `pnpm lint` clean output. Screenshots not required; CLI logs/examples are helpful.
+
+- Use Conventional Commits: `feat`, `fix`, `docs`, `chore`, `test`, `refactor`, `perf`, `ci`, `build`, `style`.
+  Example: `feat(cli): add --fail-fast flag` or `fix: ensure retry backoff doubles`.
+- Keep commits small and focused; reference issues/PRs when relevant (e.g., `(#7)`).
+- PRs: include purpose, behavior changes (with before/after if applicable), tests, and lint-clean output. Update `README.md` and the example config when flags/options change.
 
 ## Security & Configuration Tips
+
 - Avoid committing real `.crawlsnaprc.json` with sensitive URLs; use the example file.
 - Output defaults to `generated-screenshots/` under the chosen `--output` dir; do not commit artifacts.
 - When adding options, validate inputs and respect existing defaults to prevent breaking changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,9 @@
 
 ## Build, Test, and Development Commands
 
-- `npm run dev` or `pnpm dev`: Run in watch mode with tsx. Pass CLI args after `--`.
-  Example: `pnpm dev -- https://example.com --desktop`.
+- `npm run dev` or `pnpm dev`: Launches the web UI (React + Vite) and dev API server. Enter a URL, tweak options, run/abort, view logs.
+  - `pnpm dev:cli -- <args>`: Watch the CLI entry with your own args.
+    Example: `pnpm dev:cli -- https://example.com --desktop`.
 - `npm run build` or `pnpm build`: Type-check and compile to `dist/`.
 - `npm start` or `pnpm start`: Run compiled CLI (`node dist/index.js`).
 - `npm test` / `pnpm test`: Run unit tests (Vitest).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `src/`: TypeScript sources and colocated tests (`*.test.ts`).
+- `dist/`: Compiled JS and types (`tsc` output). Do not edit.
+- `static/`: Static assets (icons, images).
+- `README.md`: CLI usage and examples.
+- `vitest.config.ts`, `tsconfig.json`, `eslint.config.mjs`, `.prettierrc`: Tooling config.
+- Config file example: `.crawlsnaprc.example.json` (users may copy to `.crawlsnaprc.json`).
+
+## Build, Test, and Development Commands
+- `npm run dev` or `pnpm dev`: Run in watch mode with tsx. Pass CLI args after `--`.
+  Example: `pnpm dev -- https://example.com --desktop`.
+- `npm run build` or `pnpm build`: Type-check and compile to `dist/`.
+- `npm start` or `pnpm start`: Run compiled CLI (`node dist/index.js`).
+- `npm test` / `pnpm test`: Run unit tests (Vitest).
+- `pnpm test:watch`: Watch mode for tests.
+- `npm run lint` / `pnpm lint`: ESLint checks. `lint:fix` to autofix.
+- `npm run format`: Prettier formatting (Markdown is ignored by default).
+- First-time Playwright setup: `npx playwright install` (or `pnpx playwright install`).
+
+## Coding Style & Naming Conventions
+- Language: TypeScript (Node >= 20).
+- Indentation: 2 spaces; single quotes; semicolons; width 100 (Prettier enforced).
+- File names: kebab-case for files, `*.test.ts` for tests colocated with sources.
+- Linting: ESLint with `@typescript-eslint` (see `eslint.config.mjs`). Fix warnings before PRs.
+
+## Testing Guidelines
+- Framework: Vitest with V8 coverage (`text`, `lcov`, `html`).
+- Location: tests live next to code in `src/` and end with `.test.ts`.
+- Run: `pnpm test` (or `npm test`). Coverage reports emit to `coverage/`.
+
+## Commit & Pull Request Guidelines
+- Commits: short, imperative subject; reference PRs/issues when relevant (e.g., "Fix badges (#3)").
+- Scope small; keep changes focused. Update `README.md` and `.crawlsnaprc.example.json` when flags/options change.
+- PRs: include description, rationale, before/after if behavior changes, test coverage, and `pnpm lint` clean output. Screenshots not required; CLI logs/examples are helpful.
+
+## Security & Configuration Tips
+- Avoid committing real `.crawlsnaprc.json` with sensitive URLs; use the example file.
+- Output defaults to `generated-screenshots/` under the chosen `--output` dir; do not commit artifacts.
+- When adding options, validate inputs and respect existing defaults to prevent breaking changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Pre-commit Hooks
 
 The project uses Husky and lint-staged to automatically:
+
 - Format code with Prettier
 - Fix ESLint issues
 - These hooks only run on changed files when committing
@@ -56,7 +57,7 @@ This project is a CLI tool for taking website screenshots at various resolutions
 ### Browser Support
 
 - Chromium (default)
-- Firefox  
+- Firefox
 - WebKit
 
 ### Output Structure

--- a/README.md
+++ b/README.md
@@ -83,8 +83,12 @@ Options:
   -p, --max-pages <n>      Maximum number of pages to crawl (only used with --crawl) (default: 50)
   -t, --timeout <ms>       Early screenshot timeout in milliseconds (default: 5000, max Playwright timeout: 30000)
   --concurrency <n>        Maximum number of concurrent screenshot operations (default: 3)
-  -r, --retries <n>        Number of retry attempts for failed screenshots (default: 2)
+  -R, --retries <n>        Number of retry attempts for failed screenshots (default: 2)
   -x, --exclude-pattern    URL patterns to exclude from crawling (supports wildcards like */admin/*). Repeatable.
+  -i, --include-pattern    URL patterns to include when crawling (supports wildcards). Repeatable.
+  --wait-until <state>     Navigation waitUntil (load | domcontentloaded | networkidle | commit) (default: networkidle)
+  --delay <ms>             Delay before screenshot after navigation/timeout (ms) (default: 0)
+  --no-full-page           Capture only the visible viewport (default is full page)
   --continue-on-error      Continue processing other URLs/resolutions when errors occur (default: true)
   --fail-fast              Stop processing immediately when any error occurs
   -V, --version            Output the version number

--- a/README.md
+++ b/README.md
@@ -310,6 +310,25 @@ pnpm lint
 pnpm lint:fix
 ```
 
+### Local Dev UI
+
+Run the web UI (React + Vite) that mirrors CLI options and streams logs:
+
+```bash
+pnpm dev
+```
+
+This starts:
+
+- Dev API: `http://localhost:3001` (proxies from Vite), spawns the CLI with your options
+- Web UI: `http://localhost:5173` (auto-opens in the terminal)
+
+You can enter a URL, adjust options, run/abort, and watch logs live. For direct CLI watching with your own args:
+
+```bash
+pnpm dev:cli -- https://example.com --desktop
+```
+
 ## CI/CD
 
 This project uses GitHub Actions for continuous integration and deployment:

--- a/README.md
+++ b/README.md
@@ -18,11 +18,14 @@ A CLI tool for taking website screenshots at various resolutions using Playwrigh
 
 ## Features
 
-- Take full page screenshots at specified resolutions
-- Capture multiple resolutions in a single run
+- Take full page screenshots at specified resolutions with **parallel processing**
+- Capture multiple resolutions in a single run with configurable concurrency
 - Built-in presets for desktop and mobile devices
 - Optional website crawling to automatically capture linked pages
-- Configurable crawl depth and maximum page limits
+- Configurable crawl depth and maximum page limits with URL exclusion patterns
+- **Automatic retry logic** for failed screenshots with exponential backoff
+- **Configuration file support** (.crawlsnaprc.json) for project-specific settings
+- **Advanced error recovery** with detailed error classification and reporting
 - Support for Chromium, Firefox, and WebKit browsers
 - Organized output directory structure with automatic run numbering
 
@@ -68,19 +71,24 @@ pnpx @rosbel/crawl-n-snap https://example.com [options]
 
 ```
 Arguments:
-  url                     The full URL (including http/https) of the page to screenshot.
+  url                      The full URL (including http/https) of the page to screenshot.
 
 Options:
-  -r, --resolution <WxH>  Custom screen resolution (e.g., 1920x1080). Repeatable.
-  -d, --desktop           Capture desktop resolutions (1920x1080)
-  -m, --mobile            Capture mobile resolutions (390x844)
-  -o, --output <dir>      Base output directory for screenshots (default: current directory)
-  -b, --browser <n>       Browser to use (chromium, firefox, webkit) (default: "chromium")
-  -c, --crawl             Enable crawling of all relative links on the website
-  -p, --max-pages <n>     Maximum number of pages to crawl (only used with --crawl) (default: 50)
-  -t, --timeout <ms>      Early screenshot timeout in milliseconds (default: 5000, max Playwright timeout: 30000)
-  -V, --version           Output the version number
-  -h, --help              Display help for command
+  -r, --resolution <WxH>   Custom screen resolution (e.g., 1920x1080). Repeatable.
+  -d, --desktop            Capture desktop resolutions (1920x1080)
+  -m, --mobile             Capture mobile resolutions (390x844)
+  -o, --output <dir>       Base output directory for screenshots (default: current directory)
+  -b, --browser <name>     Browser to use (chromium, firefox, webkit) (default: "chromium")
+  -c, --crawl              Enable crawling of all relative links on the website
+  -p, --max-pages <n>      Maximum number of pages to crawl (only used with --crawl) (default: 50)
+  -t, --timeout <ms>       Early screenshot timeout in milliseconds (default: 5000, max Playwright timeout: 30000)
+  --concurrency <n>        Maximum number of concurrent screenshot operations (default: 3)
+  -r, --retries <n>        Number of retry attempts for failed screenshots (default: 2)
+  -x, --exclude-pattern    URL patterns to exclude from crawling (supports wildcards like */admin/*). Repeatable.
+  --continue-on-error      Continue processing other URLs/resolutions when errors occur (default: true)
+  --fail-fast              Stop processing immediately when any error occurs
+  -V, --version            Output the version number
+  -h, --help               Display help for command
 ```
 
 ### Examples
@@ -127,6 +135,53 @@ npx @rosbel/crawl-n-snap https://example.com --timeout 5000
 
 Note: The tool will attempt to take a screenshot after the specified timeout even if the page is still loading. Playwright has a fixed maximum timeout of 30 seconds for network idle.
 
+#### Use configuration file for project settings
+
+```bash
+npx @rosbel/crawl-n-snap https://example.com
+```
+
+If a `.crawlsnaprc.json` file exists in the current directory or home directory:
+
+```json
+{
+  "resolutions": ["1920x1080", "1366x768", "390x844"],
+  "browser": "firefox",
+  "output": "./screenshots",
+  "crawl": true,
+  "maxPages": 20,
+  "timeout": 7000,
+  "concurrency": 2,
+  "retries": 3,
+  "continueOnError": true,
+  "excludePatterns": ["*/admin/*", "*/login/*"]
+}
+```
+
+#### Exclude URLs from crawling
+
+```bash
+npx @rosbel/crawl-n-snap https://example.com --crawl \
+  --exclude-pattern "*/admin/*" \
+  --exclude-pattern "*/login/*" \
+  --exclude-pattern "*checkout*"
+```
+
+#### Control concurrency and retries
+
+```bash
+npx @rosbel/crawl-n-snap https://example.com \
+  --concurrency 5 \
+  --retries 3 \
+  --continue-on-error
+```
+
+#### Stop on first error (fail fast)
+
+```bash
+npx @rosbel/crawl-n-snap https://example.com --fail-fast
+```
+
 ## Output Structure
 
 Screenshots are saved with the following structure:
@@ -140,6 +195,89 @@ For example:
 ./generated-screenshots/example.com/20240328/1/1920x1080-root.png
 ./generated-screenshots/example.com/20240328/1/1920x1080-about.png
 ```
+
+## Configuration File
+
+Crawl-n-Snap supports configuration files to store project-specific settings. The tool looks for configuration files in this order:
+
+1. `.crawlsnaprc.json` in the current directory
+2. `.crawlsnaprc` in the current directory  
+3. `.crawlsnaprc.json` in the home directory
+4. `.crawlsnaprc` in the home directory
+
+### Configuration Options
+
+All CLI options can be specified in the configuration file. CLI options take precedence over configuration file settings.
+
+```json
+{
+  "resolutions": ["1920x1080", "1366x768", "390x844"],
+  "browser": "chromium",
+  "output": "./screenshots",
+  "crawl": false,
+  "maxPages": 50,
+  "timeout": 5000,
+  "concurrency": 3,
+  "retries": 2,
+  "continueOnError": true,
+  "desktop": false,
+  "mobile": false,
+  "excludePatterns": ["*/admin/*", "*/login/*", "*checkout*"]
+}
+```
+
+### Exclude Patterns
+
+Exclude patterns support glob-like wildcards:
+
+- `*/admin/*` - Excludes any URL containing `/admin/` in the path
+- `*login*` - Excludes any URL containing "login" anywhere
+- `https://*/internal/*` - Excludes internal paths on any domain
+- `*/api/*` - Excludes API endpoints
+
+Patterns are case-insensitive and support standard glob wildcards (`*`).
+
+## Performance & Reliability
+
+### Parallel Processing
+
+By default, screenshots are taken in parallel (up to 3 concurrent operations) for better performance. You can adjust this with the `--concurrency` option:
+
+```bash
+# Process up to 5 screenshots simultaneously
+npx @rosbel/crawl-n-snap https://example.com --concurrency 5
+
+# Process screenshots one at a time (safest for low-memory systems)
+npx @rosbel/crawl-n-snap https://example.com --concurrency 1
+```
+
+### Retry Logic
+
+Failed screenshots are automatically retried with exponential backoff:
+
+- 1st retry: after 1 second
+- 2nd retry: after 2 seconds  
+- 3rd retry: after 4 seconds
+- etc.
+
+```bash
+# Set custom retry attempts
+npx @rosbel/crawl-n-snap https://example.com --retries 5
+
+# Disable retries
+npx @rosbel/crawl-n-snap https://example.com --retries 0
+```
+
+### Error Handling
+
+The tool provides detailed error classification and reporting:
+
+- **Navigation errors**: Timeouts, network issues, DNS resolution
+- **Screenshot errors**: Page rendering issues, memory problems
+- **File system errors**: Disk space, permissions, path issues
+- **Link extraction errors**: DOM parsing, JavaScript execution
+
+By default, the tool continues processing other URLs when errors occur. Use `--fail-fast` to stop on the first error.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Screenshots are saved with the following structure:
 ```
 
 For example:
+
 ```
 ./generated-screenshots/example.com/20240328/1/1920x1080-root.png
 ./generated-screenshots/example.com/20240328/1/1920x1080-about.png
@@ -201,7 +202,7 @@ For example:
 Crawl-n-Snap supports configuration files to store project-specific settings. The tool looks for configuration files in this order:
 
 1. `.crawlsnaprc.json` in the current directory
-2. `.crawlsnaprc` in the current directory  
+2. `.crawlsnaprc` in the current directory
 3. `.crawlsnaprc.json` in the home directory
 4. `.crawlsnaprc` in the home directory
 
@@ -256,7 +257,7 @@ npx @rosbel/crawl-n-snap https://example.com --concurrency 1
 Failed screenshots are automatically retried with exponential backoff:
 
 - 1st retry: after 1 second
-- 2nd retry: after 2 seconds  
+- 2nd retry: after 2 seconds
 - 3rd retry: after 4 seconds
 - etc.
 
@@ -312,6 +313,7 @@ This project uses GitHub Actions for continuous integration and deployment:
 ### Continuous Integration
 
 The CI workflow runs on pull requests to the main branch and includes:
+
 - Automated testing
 - Code linting
 - Build verification

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,4 +40,25 @@ export default defineConfig([
       '@typescript-eslint/no-explicit-any': 'off',
     },
   },
+  // UI (React + TSX)
+  {
+    files: ['ui/src/**/*.{ts,tsx}'],
+    plugins: {
+      '@typescript-eslint': typescriptEslint,
+    },
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+      },
+      parser: tsParser,
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      parserOptions: { ecmaFeatures: { jsx: true } },
+    },
+    rules: {
+      'no-console': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
 ]);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,40 +1,43 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import typescriptEslint from "@typescript-eslint/eslint-plugin";
-import globals from "globals";
-import tsParser from "@typescript-eslint/parser";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import js from "@eslint/js";
-import { FlatCompat } from "@eslint/eslintrc";
+import {defineConfig, globalIgnores} from 'eslint/config';
+import typescriptEslint from '@typescript-eslint/eslint-plugin';
+import globals from 'globals';
+import tsParser from '@typescript-eslint/parser';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import js from '@eslint/js';
+import {FlatCompat} from '@eslint/eslintrc';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
 });
 
-export default defineConfig([globalIgnores(["dist/**/*", "node_modules/**/*"]), {
-    extends: compat.extends("eslint:recommended", "plugin:@typescript-eslint/recommended"),
+export default defineConfig([
+  globalIgnores(['dist/**/*', 'node_modules/**/*']),
+  {
+    extends: compat.extends('eslint:recommended', 'plugin:@typescript-eslint/recommended'),
 
     plugins: {
-        "@typescript-eslint": typescriptEslint,
+      '@typescript-eslint': typescriptEslint,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-        },
+      globals: {
+        ...globals.node,
+      },
 
-        parser: tsParser,
-        ecmaVersion: 2020,
-        sourceType: "module",
+      parser: tsParser,
+      ecmaVersion: 2020,
+      sourceType: 'module',
     },
 
     rules: {
-        "no-console": "off",
-        "@typescript-eslint/explicit-module-boundary-types": "off",
-        "@typescript-eslint/no-explicit-any": "off",
+      'no-console': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
     },
-}]);
+  },
+]);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsx watch src/index.ts --",
+    "dev": "tsx scripts/dev.ts",
+    "dev:cli": "tsx watch src/index.ts --",
     "start": "node dist/index.js",
     "prepare": "husky install && npm run build",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
     "prepare": "husky install && npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "eslint src/**/*.ts",
-    "lint:fix": "eslint src/**/*.ts --fix",
+    "lint": "eslint \"src/**/*.ts\" \"ui/src/**/*.{ts,tsx}\"",
+    "lint:fix": "eslint \"src/**/*.ts\" \"ui/src/**/*.{ts,tsx}\" --fix",
+    "lint:ui": "eslint \"ui/src/**/*.{ts,tsx}\"",
+    "test:ui": "vitest run",
     "format": "prettier --write .",
     "lint-staged": "lint-staged"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:watch": "vitest",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
-    "format": "prettier --write",
+    "format": "prettier --write .",
     "lint-staged": "lint-staged"
   },
   "keywords": [

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,0 +1,36 @@
+import {spawn, spawnSync} from 'node:child_process';
+import {existsSync} from 'node:fs';
+
+function run(cmd: string, args: string[], name: string) {
+  const p = spawn(cmd, args, {stdio: 'inherit', env: process.env});
+  p.on('exit', (code) => {
+    if (code && code !== 0) {
+      console.error(`${name} exited with code ${code}`);
+      process.exit(code);
+    }
+  });
+  return p;
+}
+
+// Ensure UI deps are installed
+if (!existsSync('ui/node_modules')) {
+  console.log('[dev] Installing UI dependencies...');
+  const r = spawnSync('pnpm', ['--dir', 'ui', 'install'], {stdio: 'inherit'});
+  if (r.status && r.status !== 0) {
+    console.error('[dev] Failed to install UI dependencies.');
+    process.exit(r.status ?? 1);
+  }
+}
+
+// Start API server
+const api = run(process.execPath, ['--import', 'tsx', 'src/dev-server.ts'], 'api');
+
+// Start Vite dev server in ui/
+const ui = run('pnpm', ['--dir', 'ui', 'dev'], 'ui');
+
+// Graceful shutdown
+process.on('SIGINT', () => {
+  api.kill('SIGTERM');
+  ui.kill('SIGTERM');
+  process.exit(0);
+});

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,316 @@
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import {parseResolution} from './utils';
+
+// Mock fs module
+vi.mock('fs/promises');
+const mockedFs = vi.mocked(fs);
+
+// Mock os module
+vi.mock('os');
+const mockedOs = vi.mocked(os);
+
+// Recreate the config loading function for testing
+interface ConfigFile {
+  resolutions?: string[];
+  output?: string;
+  browser?: 'chromium' | 'firefox' | 'webkit';
+  crawl?: boolean;
+  maxPages?: number;
+  timeout?: number;
+  concurrency?: number;
+  retries?: number;
+  continueOnError?: boolean;
+  desktop?: boolean;
+  mobile?: boolean;
+  excludePatterns?: string[];
+}
+
+const supportedBrowsers: ('chromium' | 'firefox' | 'webkit')[] = ['chromium', 'firefox', 'webkit'];
+
+async function loadConfigFile(): Promise<ConfigFile | null> {
+  const configFilenames = ['.crawlsnaprc.json', '.crawlsnaprc'];
+  const searchPaths = [
+    process.cwd(), // Current directory
+    os.homedir(), // Home directory
+  ];
+
+  for (const searchPath of searchPaths) {
+    for (const filename of configFilenames) {
+      const configPath = path.join(searchPath, filename);
+      try {
+        const configContent = await fs.readFile(configPath, 'utf8');
+        const config = JSON.parse(configContent) as ConfigFile;
+
+        // Validate browser if specified
+        if (config.browser && !supportedBrowsers.includes(config.browser)) {
+          console.warn(`Invalid browser "${config.browser}" in ${configPath}. Using default.`);
+          delete config.browser;
+        }
+
+        console.log(`Using configuration from: ${configPath}`);
+        return config;
+      } catch (error: any) {
+        // File doesn't exist or is invalid, continue searching
+        if (error.code !== 'ENOENT') {
+          console.warn(`Warning: Could not parse config file ${configPath}: ${error.message}`);
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+// Function to merge config file with CLI options (CLI takes precedence)
+function mergeConfigWithOptions(config: ConfigFile | null, cliOptions: any): any {
+  if (!config) return cliOptions;
+
+  // Merge exclude patterns from both CLI and config
+  const excludePatterns = [...(cliOptions.excludePattern || []), ...(config.excludePatterns || [])];
+
+  return {
+    resolution:
+      cliOptions.resolution.length === 1 &&
+      cliOptions.resolution[0].width === 1920 &&
+      cliOptions.resolution[0].height === 1080
+        ? config.resolutions?.map(parseResolution) || cliOptions.resolution // Use config if CLI has default
+        : cliOptions.resolution, // Use CLI if custom resolutions provided
+    output: cliOptions.output !== '.' ? cliOptions.output : config.output || cliOptions.output,
+    browser:
+      cliOptions.browser !== 'chromium' ? cliOptions.browser : config.browser || cliOptions.browser,
+    crawl: cliOptions.crawl || config.crawl || false,
+    maxPages:
+      cliOptions.maxPages !== 50 ? cliOptions.maxPages : config.maxPages || cliOptions.maxPages,
+    timeout:
+      cliOptions.timeout !== 5000 ? cliOptions.timeout : config.timeout || cliOptions.timeout,
+    concurrency:
+      cliOptions.concurrency !== 3
+        ? cliOptions.concurrency
+        : config.concurrency || cliOptions.concurrency,
+    retries: cliOptions.retries !== 2 ? cliOptions.retries : (config.retries ?? cliOptions.retries),
+    excludePattern: excludePatterns,
+    continueOnError: cliOptions.failFast
+      ? false
+      : (cliOptions.continueOnError ?? config.continueOnError ?? true),
+    desktop: cliOptions.desktop || config.desktop || false,
+    mobile: cliOptions.mobile || config.mobile || false,
+  };
+}
+
+describe('Configuration File Loading', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockedOs.homedir.mockReturnValue('/home/user');
+    vi.spyOn(process, 'cwd').mockReturnValue('/current/dir');
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null when no config file is found', async () => {
+    mockedFs.readFile.mockRejectedValue({code: 'ENOENT'});
+
+    const result = await loadConfigFile();
+    expect(result).toBeNull();
+
+    // Should check both filenames in both directories
+    expect(mockedFs.readFile).toHaveBeenCalledTimes(4);
+    expect(mockedFs.readFile).toHaveBeenCalledWith('/current/dir/.crawlsnaprc.json', 'utf8');
+    expect(mockedFs.readFile).toHaveBeenCalledWith('/current/dir/.crawlsnaprc', 'utf8');
+    expect(mockedFs.readFile).toHaveBeenCalledWith('/home/user/.crawlsnaprc.json', 'utf8');
+    expect(mockedFs.readFile).toHaveBeenCalledWith('/home/user/.crawlsnaprc', 'utf8');
+  });
+
+  it('loads and parses valid config file from current directory', async () => {
+    const configData = {
+      resolutions: ['1920x1080', '390x844'],
+      browser: 'firefox',
+      output: './screenshots',
+      crawl: true,
+      maxPages: 100,
+    };
+
+    mockedFs.readFile
+      .mockResolvedValueOnce(JSON.stringify(configData))
+      .mockRejectedValue({code: 'ENOENT'});
+
+    const result = await loadConfigFile();
+    expect(result).toEqual(configData);
+    expect(console.log).toHaveBeenCalledWith(
+      'Using configuration from: /current/dir/.crawlsnaprc.json'
+    );
+  });
+
+  it('loads config from home directory if not found in current directory', async () => {
+    const configData = {
+      browser: 'webkit',
+      concurrency: 5,
+    };
+
+    mockedFs.readFile
+      .mockRejectedValueOnce({code: 'ENOENT'}) // .crawlsnaprc.json in current dir
+      .mockRejectedValueOnce({code: 'ENOENT'}) // .crawlsnaprc in current dir
+      .mockResolvedValueOnce(JSON.stringify(configData)); // .crawlsnaprc.json in home dir
+
+    const result = await loadConfigFile();
+    expect(result).toEqual(configData);
+    expect(console.log).toHaveBeenCalledWith(
+      'Using configuration from: /home/user/.crawlsnaprc.json'
+    );
+  });
+
+  it('handles invalid JSON gracefully', async () => {
+    mockedFs.readFile.mockResolvedValueOnce('{ invalid json }').mockRejectedValue({code: 'ENOENT'});
+
+    const result = await loadConfigFile();
+    expect(result).toBeNull();
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Warning: Could not parse config file /current/dir/.crawlsnaprc.json:'
+      )
+    );
+  });
+
+  it('validates and removes invalid browser option', async () => {
+    const configData = {
+      browser: 'invalid-browser',
+      output: './screenshots',
+    };
+
+    mockedFs.readFile
+      .mockResolvedValueOnce(JSON.stringify(configData))
+      .mockRejectedValue({code: 'ENOENT'});
+
+    const result = await loadConfigFile();
+    expect(result).toEqual({output: './screenshots'});
+    expect(console.warn).toHaveBeenCalledWith(
+      'Invalid browser "invalid-browser" in /current/dir/.crawlsnaprc.json. Using default.'
+    );
+  });
+});
+
+describe('Configuration Merging', () => {
+  it('uses CLI options when no config file is provided', () => {
+    const cliOptions = {
+      resolution: [parseResolution('800x600')],
+      output: './custom',
+      browser: 'firefox',
+      crawl: true,
+      maxPages: 20,
+      timeout: 3000,
+      concurrency: 2,
+      retries: 1,
+      continueOnError: false,
+      excludePattern: ['*/admin/*'],
+      desktop: false,
+      mobile: true,
+      failFast: false,
+    };
+
+    const result = mergeConfigWithOptions(null, cliOptions);
+    expect(result).toEqual({
+      ...cliOptions,
+      excludePattern: ['*/admin/*'],
+    });
+  });
+
+  it('merges config file with CLI options (CLI takes precedence)', () => {
+    const config: ConfigFile = {
+      resolutions: ['1366x768', '390x844'],
+      browser: 'webkit',
+      output: './config-output',
+      crawl: false,
+      maxPages: 30,
+      timeout: 7000,
+      concurrency: 4,
+      retries: 3,
+      continueOnError: false,
+      excludePatterns: ['*/config-exclude/*'],
+    };
+
+    const cliOptions = {
+      resolution: [parseResolution('800x600')], // Custom resolution - should override config
+      output: './cli-output', // Non-default - should override config
+      browser: 'chromium', // Default value - should use config
+      crawl: true, // Explicit true - should override config false
+      maxPages: 50, // Default value - should use config
+      timeout: 5000, // Default value - should use config
+      concurrency: 3, // Default value - should use config
+      retries: 2, // Default value - should use config
+      continueOnError: undefined, // Default value - should use config
+      excludePattern: ['*/cli-exclude/*'],
+      desktop: false,
+      mobile: false,
+      failFast: false,
+    };
+
+    const result = mergeConfigWithOptions(config, cliOptions);
+
+    expect(result.resolution).toEqual([parseResolution('800x600')]);
+    expect(result.output).toBe('./cli-output');
+    expect(result.browser).toBe('webkit'); // From config
+    expect(result.crawl).toBe(true); // From CLI (explicit true)
+    expect(result.maxPages).toBe(30); // From config (CLI has default)
+    expect(result.timeout).toBe(7000); // From config (CLI has default)
+    expect(result.concurrency).toBe(4); // From config (CLI has default)
+    expect(result.retries).toBe(3); // From config (CLI has default)
+    expect(result.continueOnError).toBe(false); // From config (CLI has undefined/default)
+    expect(result.excludePattern).toEqual(['*/cli-exclude/*', '*/config-exclude/*']); // Merged
+  });
+
+  it('handles failFast option correctly', () => {
+    const config: ConfigFile = {
+      continueOnError: true,
+    };
+
+    const cliOptionsWithFailFast = {
+      resolution: [parseResolution('1920x1080')],
+      output: '.',
+      browser: 'chromium',
+      crawl: false,
+      maxPages: 50,
+      timeout: 5000,
+      concurrency: 3,
+      retries: 2,
+      continueOnError: true,
+      excludePattern: [],
+      desktop: false,
+      mobile: false,
+      failFast: true, // This should override continueOnError to false
+    };
+
+    const result = mergeConfigWithOptions(config, cliOptionsWithFailFast);
+    expect(result.continueOnError).toBe(false);
+  });
+
+  it('uses config resolutions when CLI has default resolution', () => {
+    const config: ConfigFile = {
+      resolutions: ['800x600', '1366x768'],
+    };
+
+    const cliOptionsWithDefault = {
+      resolution: [parseResolution('1920x1080')], // Default resolution
+      output: '.',
+      browser: 'chromium',
+      crawl: false,
+      maxPages: 50,
+      timeout: 5000,
+      concurrency: 3,
+      retries: 2,
+      continueOnError: true,
+      excludePattern: [],
+      desktop: false,
+      mobile: false,
+      failFast: false,
+    };
+
+    const result = mergeConfigWithOptions(config, cliOptionsWithDefault);
+    expect(result.resolution).toEqual([parseResolution('800x600'), parseResolution('1366x768')]);
+  });
+});

--- a/src/dev-server.ts
+++ b/src/dev-server.ts
@@ -1,0 +1,421 @@
+import http from 'node:http';
+import {spawn, ChildProcessWithoutNullStreams} from 'node:child_process';
+import {parse} from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs';
+
+type RunStatus = 'running' | 'completed' | 'failed' | 'aborted';
+
+interface RunRecord {
+  id: string;
+  child: ChildProcessWithoutNullStreams | null;
+  logs: string[];
+  status: RunStatus;
+  startedAt: number;
+  finishedAt?: number;
+  exitCode?: number | null;
+  manifestPath?: string;
+  subscribers: Set<http.ServerResponse>;
+  metrics: {
+    pageCurrent: number;
+    pageTotal: number;
+    resCurrent: number;
+    resTotal: number;
+  };
+  url: string;
+  payload: any;
+}
+
+const runs = new Map<string, RunRecord>();
+
+function json(res: http.ServerResponse, status: number, body: any) {
+  const text = JSON.stringify(body);
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+  });
+  res.end(text);
+}
+
+function parseBody(req: http.IncomingMessage): Promise<any> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      const text = Buffer.concat(chunks).toString('utf8');
+      try {
+        resolve(text ? JSON.parse(text) : {});
+      } catch {
+        resolve({});
+      }
+    });
+  });
+}
+
+function newId() {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+function optionsToArgs(payload: any): string[] {
+  const args: string[] = [];
+  // Order roughly mirrors CLI
+  const res: string[] = payload.resolutions || [];
+  res.forEach((r) => args.push('-r', r));
+
+  if (payload.desktop) args.push('--desktop');
+  if (payload.mobile) args.push('--mobile');
+  if (payload.output) args.push('-o', payload.output);
+  if (payload.browser) args.push('-b', payload.browser);
+  if (payload.crawl) args.push('-c');
+  if (payload.maxPages != null) args.push('-p', String(payload.maxPages));
+  if (payload.timeout != null) args.push('-t', String(payload.timeout));
+  if (payload.concurrency != null) args.push('--concurrency', String(payload.concurrency));
+  if (payload.retries != null) args.push('-R', String(payload.retries));
+  (payload.excludePatterns || []).forEach((p: string) => args.push('-x', p));
+  (payload.includePatterns || []).forEach((p: string) => args.push('-i', p));
+
+  if (payload.continueOnError === false) args.push('--continue-on-error', 'false');
+  if (payload.failFast) args.push('--fail-fast');
+  if (payload.waitUntil) args.push('--wait-until', payload.waitUntil);
+  if (payload.delay != null) args.push('--delay', String(payload.delay));
+  if (payload.fullPage === false) args.push('--no-full-page');
+  if (payload.headless === false) args.push('--no-headless');
+  return args;
+}
+
+function startRun(body: any): RunRecord {
+  const id = newId();
+  const url = String(body.url || '');
+  const args = optionsToArgs(body);
+
+  const child = spawn(process.execPath, ['--import', 'tsx', 'src/index.ts', url, ...args], {
+    env: process.env,
+    stdio: 'pipe',
+  });
+
+  const rec: RunRecord = {
+    id,
+    child,
+    logs: [],
+    status: 'running',
+    startedAt: Date.now(),
+    exitCode: undefined,
+    subscribers: new Set(),
+    metrics: {pageCurrent: 0, pageTotal: 0, resCurrent: 0, resTotal: 0},
+    url,
+    payload: body,
+  };
+  runs.set(id, rec);
+
+  const append = (buf: Buffer) => {
+    const text = buf.toString('utf8');
+    const lines = text.split(/\r?\n/);
+    rec.logs.push(...lines);
+    // parse metrics
+    for (const line of lines) {
+      if (!line) continue;
+      let m = line.match(/^\[(\d+)\/(\d+)\] Processing URL:/);
+      if (m) {
+        rec.metrics.pageCurrent = parseInt(m[1], 10);
+        rec.metrics.pageTotal = parseInt(m[2], 10);
+        rec.metrics.resCurrent = 0;
+        rec.metrics.resTotal = 0;
+        broadcast(rec, 'metrics', rec.metrics);
+        continue;
+      }
+      m = line.match(/Processing (\d+) resolutions/);
+      if (m) {
+        rec.metrics.resTotal = parseInt(m[1], 10);
+        rec.metrics.resCurrent = 0;
+        broadcast(rec, 'metrics', rec.metrics);
+        continue;
+      }
+      if (/^✓ .* screenshot saved:/.test(line) || /^✗ .* failed/.test(line)) {
+        rec.metrics.resCurrent = Math.min(
+          rec.metrics.resCurrent + 1,
+          rec.metrics.resTotal || rec.metrics.resCurrent + 1
+        );
+        broadcast(rec, 'metrics', rec.metrics);
+      }
+    }
+    // broadcast new logs
+    const nonEmpty = lines.filter(Boolean);
+    if (nonEmpty.length) {
+      broadcast(rec, 'logs', {lines: nonEmpty, next: rec.logs.length});
+    }
+    // capture manifest path if logged
+    const match = text.match(/Run manifest written: (.*)$/m);
+    if (match) rec.manifestPath = match[1].trim();
+  };
+
+  child.stdout.on('data', append);
+  child.stderr.on('data', append);
+  child.on('exit', (code) => {
+    rec.exitCode = code;
+    rec.finishedAt = Date.now();
+    rec.status = code === 0 ? 'completed' : 'failed';
+    broadcast(rec, 'status', {
+      status: rec.status,
+      exitCode: rec.exitCode ?? null,
+      manifestPath: rec.manifestPath || null,
+      startedAt: rec.startedAt,
+      finishedAt: rec.finishedAt || null,
+    });
+  });
+
+  return rec;
+}
+
+const server = http.createServer(async (req, res) => {
+  // CORS preflight
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET,POST,DELETE,OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    });
+    return res.end();
+  }
+
+  const url = parse(req.url || '', true);
+  const pathname = url.pathname || '';
+
+  if (req.method === 'GET' && pathname === '/api/health') {
+    return json(res, 200, {ok: true});
+  }
+
+  if (req.method === 'GET' && pathname === '/api/runs') {
+    const list = Array.from(runs.values())
+      .sort((a, b) => b.startedAt - a.startedAt)
+      .map((r) => ({
+        id: r.id,
+        url: r.url,
+        status: r.status,
+        startedAt: r.startedAt,
+        finishedAt: r.finishedAt ?? null,
+        exitCode: r.exitCode ?? null,
+        manifestPath: r.manifestPath || null,
+      }));
+    return json(res, 200, list);
+  }
+
+  if (req.method === 'GET' && pathname.startsWith('/api/run/') && !pathname.endsWith('/manifest')) {
+    const id = pathname.split('/').pop()!;
+    const rec = runs.get(id);
+    if (!rec) return json(res, 404, {error: 'not found'});
+    return json(res, 200, {
+      id: rec.id,
+      url: rec.url,
+      status: rec.status,
+      startedAt: rec.startedAt,
+      finishedAt: rec.finishedAt ?? null,
+      exitCode: rec.exitCode ?? null,
+      manifestPath: rec.manifestPath || null,
+      payload: rec.payload,
+    });
+  }
+
+  if (req.method === 'POST' && pathname === '/api/run') {
+    const body = await parseBody(req);
+    if (!body.url) return json(res, 400, {error: 'url required'});
+    const rec = startRun(body);
+    return json(res, 200, {runId: rec.id});
+  }
+
+  if (req.method === 'GET' && pathname.startsWith('/api/logs/')) {
+    const id = pathname.split('/').pop()!;
+    const rec = runs.get(id);
+    if (!rec) return json(res, 404, {error: 'not found'});
+    const since = Number(url.query.since || 0);
+    const logs = rec.logs.slice(since);
+    return json(res, 200, {
+      status: rec.status,
+      logs,
+      next: since + logs.length,
+      exitCode: rec.exitCode ?? null,
+      manifestPath: rec.manifestPath || null,
+      startedAt: rec.startedAt,
+      finishedAt: rec.finishedAt || null,
+    });
+  }
+
+  // Serve static file (screenshots/manifests). Limited to within cwd for dev safety.
+  if (req.method === 'GET' && pathname === '/api/file') {
+    const q = parse(req.url || '', true).query;
+    const p = (q.path as string) || '';
+    if (!p) return json(res, 400, {error: 'path required'});
+    const root = process.cwd();
+    const abs = path.resolve(p);
+    if (!abs.startsWith(root)) {
+      return json(res, 403, {error: 'forbidden'});
+    }
+    if (!fs.existsSync(abs)) return json(res, 404, {error: 'not found'});
+    const ext = path.extname(abs).toLowerCase();
+    const type =
+      ext === '.png'
+        ? 'image/png'
+        : ext === '.jpg' || ext === '.jpeg'
+          ? 'image/jpeg'
+          : ext === '.webp'
+            ? 'image/webp'
+            : 'application/octet-stream';
+    res.writeHead(200, {
+      'Content-Type': type,
+      'Cache-Control': 'no-cache',
+      'Access-Control-Allow-Origin': '*',
+    });
+    const stream = fs.createReadStream(abs);
+    stream.pipe(res);
+    stream.on('error', () => {
+      if (!res.headersSent) res.writeHead(500);
+      res.end();
+    });
+    return;
+  }
+
+  if (req.method === 'GET' && pathname.startsWith('/api/run/') && pathname.endsWith('/manifest')) {
+    const parts = pathname.split('/');
+    const id = parts[parts.length - 2];
+    const rec = runs.get(id);
+    if (!rec) return json(res, 404, {error: 'not found'});
+    if (!rec.manifestPath) return json(res, 404, {error: 'manifest not available'});
+    try {
+      const content = fs.readFileSync(rec.manifestPath, 'utf8');
+      const dl = (parse(req.url || '', true).query.download ?? '').toString();
+      if (dl === '1' || dl === 'true') {
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'Content-Disposition': `attachment; filename="run-${id}.json"`,
+          'Access-Control-Allow-Origin': '*',
+        });
+        return res.end(content);
+      }
+      res.writeHead(200, {'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*'});
+      return res.end(content);
+    } catch (e: any) {
+      return json(res, 500, {error: String(e?.message || e)});
+    }
+  }
+
+  if (req.method === 'POST' && pathname === '/api/open') {
+    const body = await parseBody(req);
+    const p = String(body.path || '');
+    const mode = (body.mode as 'file' | 'dir' | 'reveal') || 'file';
+    if (!p) return json(res, 400, {error: 'path required'});
+
+    const abs = path.resolve(p);
+    // basic safety: ensure path exists
+    if (!fs.existsSync(abs)) return json(res, 404, {error: 'path not found'});
+
+    const isDir = fs.statSync(abs).isDirectory();
+    try {
+      const platform = process.platform;
+      let cmd: string;
+      let args: string[] = [];
+      if (platform === 'darwin') {
+        if (mode === 'reveal' && !isDir) {
+          cmd = 'open';
+          args = ['-R', abs];
+        } else {
+          cmd = 'open';
+          args = [mode === 'dir' && !isDir ? path.dirname(abs) : abs];
+        }
+      } else if (platform === 'win32') {
+        if (mode === 'reveal' && !isDir) {
+          cmd = 'explorer';
+          args = ['/select,', abs];
+        } else {
+          cmd = 'explorer';
+          args = [mode === 'dir' && !isDir ? path.dirname(abs) : abs];
+        }
+      } else {
+        // linux and others
+        cmd = 'xdg-open';
+        args = [mode === 'dir' && !isDir ? path.dirname(abs) : abs];
+      }
+
+      const child = spawn(cmd, args, {stdio: 'ignore', detached: true});
+      child.unref();
+      return json(res, 200, {ok: true});
+    } catch (e: any) {
+      return json(res, 500, {error: String(e?.message || e)});
+    }
+  }
+
+  // SSE for live events
+  if (req.method === 'GET' && pathname.startsWith('/api/events/')) {
+    const id = pathname.split('/').pop()!;
+    const rec = runs.get(id);
+    if (!rec) {
+      res.writeHead(404, {'Content-Type': 'text/plain'});
+      return res.end('not found');
+    }
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'Access-Control-Allow-Origin': '*',
+    });
+
+    const send = (event: string, data: any) => {
+      res.write(`event: ${event}\n`);
+      res.write(`data: ${JSON.stringify(data)}\n\n`);
+    };
+
+    // initial dump
+    send('status', {
+      status: rec.status,
+      exitCode: rec.exitCode ?? null,
+      manifestPath: rec.manifestPath || null,
+      startedAt: rec.startedAt,
+      finishedAt: rec.finishedAt || null,
+    });
+    if (rec.logs.length) {
+      send('logs', {lines: rec.logs.filter(Boolean), next: rec.logs.length});
+    }
+    send('metrics', rec.metrics);
+
+    rec.subscribers.add(res);
+
+    const ping = setInterval(() => {
+      res.write(': ping\n\n');
+    }, 15000);
+
+    res.on('close', () => {
+      clearInterval(ping);
+      rec.subscribers.delete(res);
+    });
+    return;
+  }
+
+  if (req.method === 'DELETE' && pathname.startsWith('/api/run/')) {
+    const id = pathname.split('/').pop()!;
+    const rec = runs.get(id);
+    if (!rec) return json(res, 404, {error: 'not found'});
+    if (rec.child && rec.status === 'running') {
+      rec.child.kill('SIGTERM');
+      rec.status = 'aborted';
+      rec.finishedAt = Date.now();
+    }
+    return json(res, 200, {ok: true});
+  }
+
+  res.writeHead(404, {'Content-Type': 'text/plain'});
+  res.end('Not found');
+});
+
+const PORT = Number(process.env.DEV_API_PORT || 3001);
+server.listen(PORT, () => {
+  console.log(`Dev API server listening on http://localhost:${PORT}`);
+});
+
+function broadcast(rec: RunRecord, event: string, data: any) {
+  for (const sub of rec.subscribers) {
+    try {
+      sub.write(`event: ${event}\n`);
+      sub.write(`data: ${JSON.stringify(data)}\n\n`);
+    } catch {
+      // ignore write errors
+    }
+  }
+}

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -1,0 +1,137 @@
+// Interactive Dev UI (terminal) for working on crawl-n-snap without extra deps.
+
+import readline from 'node:readline';
+import {runScreenshotter, CliOptions} from './index';
+
+function createRl() {
+  return readline.createInterface({input: process.stdin, output: process.stdout});
+}
+
+function ask(rl: readline.Interface, q: string): Promise<string> {
+  return new Promise((res) => rl.question(q, (a) => res(a.trim())));
+}
+
+function parseBool(input: string, def: boolean): boolean {
+  if (!input) return def;
+  const v = input.toLowerCase();
+  return v === 'y' || v === 'yes' || v === 'true' || v === '1';
+}
+
+function parseNumber(input: string, def: number): number {
+  if (!input) return def;
+  const n = parseInt(input, 10);
+  return Number.isFinite(n) ? n : def;
+}
+
+async function main() {
+  const rl = createRl();
+
+  console.log('Crawl-n-Snap Dev UI');
+  console.log('Press Enter to accept defaults. Values can be comma-separated where noted.');
+  console.log('---');
+
+  const url = (await ask(rl, 'URL [https://example.com]: ')) || 'https://example.com';
+
+  const resInput = await ask(rl, 'Resolutions (comma-separated) [1920x1080]: ');
+  const resolutions = (resInput || '1920x1080')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const useDesktop = parseBool(await ask(rl, 'Include desktop preset 1920x1080? [Y/n]: '), true);
+  const useMobile = parseBool(await ask(rl, 'Include mobile preset 390x844? [y/N]: '), false);
+  if (useDesktop && !resolutions.includes('1920x1080')) resolutions.push('1920x1080');
+  if (useMobile && !resolutions.includes('390x844')) resolutions.push('390x844');
+
+  const browser = (await ask(rl, 'Browser (chromium|firefox|webkit) [chromium]: ')) || 'chromium';
+  const output = (await ask(rl, 'Output directory [./dev-screenshots]: ')) || './dev-screenshots';
+
+  const crawl = parseBool(await ask(rl, 'Crawl links? [y/N]: '), false);
+  const maxPages = parseNumber(await ask(rl, 'Max pages (crawl only) [50]: '), 50);
+
+  const timeout = parseNumber(await ask(rl, 'Early screenshot timeout ms [5000]: '), 5000);
+  const concurrency = parseNumber(await ask(rl, 'Concurrency [3]: '), 3);
+  const retries = parseNumber(await ask(rl, 'Retry attempts [2]: '), 2);
+
+  const includeInput = await ask(rl, 'Include patterns (comma) []: ');
+  const includePatterns = includeInput
+    ? includeInput
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
+  const excludeInput = await ask(rl, 'Exclude patterns (comma) []: ');
+  const excludePatterns = excludeInput
+    ? excludeInput
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
+
+  const waitUntil =
+    (await ask(rl, 'waitUntil (load|domcontentloaded|networkidle|commit) [networkidle]: ')) ||
+    'networkidle';
+  const delay = parseNumber(await ask(rl, 'Delay before screenshot ms [0]: '), 0);
+  const fullPage = parseBool(await ask(rl, 'Full page screenshot? [Y/n]: '), true);
+  const headless = !parseBool(await ask(rl, 'Headful (show browser UI)? [y/N]: '), false);
+
+  const failFast = parseBool(await ask(rl, 'Fail fast? [y/N]: '), false);
+  const continueOnError = failFast
+    ? false
+    : parseBool(await ask(rl, 'Continue on error? [Y/n]: '), true);
+
+  console.log('\nSummary:');
+  console.log({
+    url,
+    resolutions,
+    browser,
+    output,
+    crawl,
+    maxPages,
+    timeout,
+    concurrency,
+    retries,
+    includePatterns,
+    excludePatterns,
+    waitUntil,
+    delay,
+    fullPage,
+    headless,
+    continueOnError,
+    failFast,
+  });
+
+  const proceed = parseBool(await ask(rl, '\nStart run? [Y/n]: '), true);
+  if (!proceed) {
+    rl.close();
+    console.log('Aborted.');
+    return;
+  }
+
+  rl.close();
+
+  const options: CliOptions = {
+    resolutions,
+    output,
+    browser: browser as any,
+    crawl,
+    maxPages,
+    timeout,
+    concurrency,
+    retries,
+    includePatterns,
+    excludePatterns,
+    continueOnError,
+    waitUntil: waitUntil as any,
+    delay,
+    fullPage,
+    headless,
+  };
+
+  await runScreenshotter(url, options);
+}
+
+main().catch((err) => {
+  console.error('Dev UI failed:', err);
+  process.exit(1);
+});

--- a/src/error-handling.test.ts
+++ b/src/error-handling.test.ts
@@ -1,0 +1,136 @@
+import {describe, it, expect} from 'vitest';
+
+// We need to import or recreate the functions since they're in the main index.ts file
+// For testing purposes, let's recreate the key functions here
+
+// Recreate the error classification function for testing
+function classifyError(
+  error: any
+): 'navigation' | 'screenshot' | 'linkExtraction' | 'fileSystem' | 'unknown' {
+  const errorMessage = error?.message?.toLowerCase() || '';
+
+  if (error?.name === 'TimeoutError' || errorMessage.includes('timeout')) {
+    return 'navigation';
+  }
+  if (errorMessage.includes('screenshot') || errorMessage.includes('page.screenshot')) {
+    return 'screenshot';
+  }
+  if (
+    errorMessage.includes('enoent') ||
+    errorMessage.includes('permission') ||
+    errorMessage.includes('mkdir')
+  ) {
+    return 'fileSystem';
+  }
+  if (
+    errorMessage.includes('network') ||
+    errorMessage.includes('net::') ||
+    errorMessage.includes('connection')
+  ) {
+    return 'navigation';
+  }
+  if (errorMessage.includes('evaluate') || errorMessage.includes('link')) {
+    return 'linkExtraction';
+  }
+
+  return 'unknown';
+}
+
+// Recreate the URL exclusion function for testing (fixed version)
+function isUrlExcluded(url: string, excludePatterns: string[]): boolean {
+  if (excludePatterns.length === 0) return false;
+
+  return excludePatterns.some((pattern) => {
+    // Convert glob-like pattern to regex
+    // First replace * with placeholder, then escape regex chars, then convert placeholder to .*
+    const regexPattern = pattern
+      .replace(/\*/g, '__WILDCARD__') // Replace * with placeholder
+      .replace(/[.+^${}()|[\]\\?]/g, '\\$&') // Escape regex special chars
+      .replace(/__WILDCARD__/g, '.*'); // Convert placeholder to .*
+
+    const regex = new RegExp(`^${regexPattern}$`, 'i'); // Case insensitive
+    return regex.test(url);
+  });
+}
+
+describe('Error Classification', () => {
+  it('classifies timeout errors correctly', () => {
+    expect(classifyError({name: 'TimeoutError', message: 'Navigation timeout'})).toBe('navigation');
+    expect(classifyError({message: 'Request timeout occurred'})).toBe('navigation');
+  });
+
+  it('classifies screenshot errors correctly', () => {
+    expect(classifyError({message: 'Screenshot failed'})).toBe('screenshot');
+    expect(classifyError({message: 'page.screenshot() error'})).toBe('screenshot');
+  });
+
+  it('classifies file system errors correctly', () => {
+    expect(classifyError({message: 'ENOENT: no such file or directory'})).toBe('fileSystem');
+    expect(classifyError({message: 'Permission denied when creating mkdir'})).toBe('fileSystem');
+  });
+
+  it('classifies network errors correctly', () => {
+    expect(classifyError({message: 'Network connection failed'})).toBe('navigation');
+    expect(classifyError({message: 'net::ERR_CONNECTION_REFUSED'})).toBe('navigation');
+  });
+
+  it('classifies link extraction errors correctly', () => {
+    expect(classifyError({message: 'Failed to evaluate link selector'})).toBe('linkExtraction');
+    expect(classifyError({message: 'Link parsing error'})).toBe('linkExtraction');
+  });
+
+  it('classifies unknown errors as unknown', () => {
+    expect(classifyError({message: 'Some random error'})).toBe('unknown');
+    expect(classifyError({})).toBe('unknown');
+    expect(classifyError(null)).toBe('unknown');
+  });
+});
+
+describe('URL Exclusion Patterns', () => {
+  it('returns false when no patterns are provided', () => {
+    expect(isUrlExcluded('https://example.com/admin', [])).toBe(false);
+  });
+
+  it('matches exact URL patterns', () => {
+    const patterns = ['https://example.com/admin'];
+    expect(isUrlExcluded('https://example.com/admin', patterns)).toBe(true);
+    expect(isUrlExcluded('https://example.com/user', patterns)).toBe(false);
+  });
+
+  it('matches wildcard patterns correctly', () => {
+    const patterns = ['*/admin/*', '*/login/*'];
+    expect(isUrlExcluded('https://example.com/admin/users', patterns)).toBe(true);
+    expect(isUrlExcluded('https://example.com/login/form', patterns)).toBe(true);
+    expect(isUrlExcluded('https://example.com/public/page', patterns)).toBe(false);
+  });
+
+  it('handles case insensitive matching', () => {
+    const patterns = ['*/ADMIN/*'];
+    expect(isUrlExcluded('https://example.com/admin/users', patterns)).toBe(true);
+    expect(isUrlExcluded('https://example.com/Admin/Users', patterns)).toBe(true);
+  });
+
+  it('matches complex wildcard patterns', () => {
+    const patterns = ['*://example.com/api/*', 'https://*/internal/*'];
+    expect(isUrlExcluded('https://example.com/api/v1/users', patterns)).toBe(true);
+    expect(isUrlExcluded('http://example.com/api/auth', patterns)).toBe(true);
+    expect(isUrlExcluded('https://test.com/internal/admin', patterns)).toBe(true);
+    expect(isUrlExcluded('https://example.com/public/page', patterns)).toBe(false);
+  });
+
+  it('handles multiple patterns', () => {
+    const patterns = ['*/admin/*', '*/login', '*/logout', '*checkout*'];
+    expect(isUrlExcluded('https://shop.com/admin/dashboard', patterns)).toBe(true);
+    expect(isUrlExcluded('https://shop.com/login', patterns)).toBe(true);
+    expect(isUrlExcluded('https://shop.com/checkout/payment', patterns)).toBe(true);
+    expect(isUrlExcluded('https://shop.com/products', patterns)).toBe(false);
+  });
+
+  it('escapes regex special characters properly', () => {
+    const patterns = ['*/test.html', '*/api+data', '*/query?param=value'];
+    expect(isUrlExcluded('https://example.com/test.html', patterns)).toBe(true);
+    expect(isUrlExcluded('https://example.com/test_html', patterns)).toBe(false);
+    expect(isUrlExcluded('https://example.com/api+data', patterns)).toBe(true);
+    expect(isUrlExcluded('https://example.com/query?param=value', patterns)).toBe(true);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,14 @@ import path from 'path';
 import fs from 'fs/promises';
 import fsSync from 'fs';
 import {URL} from 'url';
-import {Resolution, parseResolution, collectResolutions, sanitizePath, normalizeUrl} from './utils';
+import {
+  Resolution,
+  parseResolution,
+  collectResolutions,
+  sanitizePath,
+  normalizeUrl,
+  sanitizeQuery,
+} from './utils';
 import os from 'os';
 
 // Define valid browser types for Playwright
@@ -24,7 +31,11 @@ interface CliOptions {
   concurrency: number;
   retries: number;
   excludePatterns: string[];
+  includePatterns: string[];
   continueOnError: boolean;
+  waitUntil: 'load' | 'domcontentloaded' | 'networkidle' | 'commit';
+  delay: number;
+  fullPage: boolean;
 }
 
 interface ErrorSummary {
@@ -47,6 +58,10 @@ interface ConfigFile {
   desktop?: boolean;
   mobile?: boolean;
   excludePatterns?: string[];
+  includePatterns?: string[];
+  waitUntil?: 'load' | 'domcontentloaded' | 'networkidle' | 'commit' | string;
+  delay?: number;
+  fullPage?: boolean;
 }
 
 // --- Configuration File Support ---
@@ -92,6 +107,11 @@ function mergeConfigWithOptions(config: ConfigFile | null, cliOptions: any): any
 
   // Merge exclude patterns from both CLI and config
   const excludePatterns = [...(cliOptions.excludePattern || []), ...(config.excludePatterns || [])];
+  const includePatterns = [...(cliOptions.includePattern || []), ...(config.includePatterns || [])];
+
+  const allowedWaitUntil = ['load', 'domcontentloaded', 'networkidle', 'commit'] as const;
+  const safeWaitUntil = (val: any) =>
+    allowedWaitUntil.includes(val) ? val : (undefined as unknown as never);
 
   return {
     resolution:
@@ -114,11 +134,19 @@ function mergeConfigWithOptions(config: ConfigFile | null, cliOptions: any): any
         : config.concurrency || cliOptions.concurrency,
     retries: cliOptions.retries !== 2 ? cliOptions.retries : (config.retries ?? cliOptions.retries),
     excludePattern: excludePatterns,
+    includePattern: includePatterns,
     continueOnError: cliOptions.failFast
       ? false
       : (cliOptions.continueOnError ?? config.continueOnError ?? true),
     desktop: cliOptions.desktop || config.desktop || false,
     mobile: cliOptions.mobile || config.mobile || false,
+    waitUntil:
+      cliOptions.waitUntil !== 'networkidle'
+        ? cliOptions.waitUntil
+        : safeWaitUntil(config.waitUntil) || cliOptions.waitUntil,
+    delay: cliOptions.delay !== 0 ? cliOptions.delay : (config.delay ?? cliOptions.delay),
+    fullPage:
+      typeof cliOptions.fullPage === 'boolean' ? cliOptions.fullPage : (config.fullPage ?? true),
   };
 }
 
@@ -134,6 +162,16 @@ function isUrlExcluded(url: string, excludePatterns: string[]): boolean {
       .replace(/\*/g, '.*'); // Convert * to .*
 
     const regex = new RegExp(`^${regexPattern}$`, 'i'); // Case insensitive
+    return regex.test(url);
+  });
+}
+
+// Function to check if a URL matches include patterns (if present)
+function isUrlIncluded(url: string, includePatterns: string[]): boolean {
+  if (!includePatterns || includePatterns.length === 0) return true; // Include all if none provided
+  return includePatterns.some((pattern) => {
+    const regexPattern = pattern.replace(/[.+^${}()|[\]\\?]/g, '\\$&').replace(/\*/g, '.*');
+    const regex = new RegExp(`^${regexPattern}$`, 'i');
     return regex.test(url);
   });
 }
@@ -305,11 +343,17 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
   console.log(`Browser: ${options.browser}`);
   console.log(`Output Directory: ${path.resolve(options.output)}`);
   console.log(`Early Screenshot Timeout: ${options.timeout}ms, Playwright Max Timeout: 30000ms`);
+  console.log(
+    `Wait Until: ${options.waitUntil}; Delay before screenshot: ${options.delay}ms; Full Page: ${options.fullPage}`
+  );
   console.log(`Crawl Mode: ${options.crawl ? 'Enabled' : 'Disabled'}`);
   if (options.crawl) {
     console.log(`Max Pages: ${options.maxPages}`);
     if (options.excludePatterns.length > 0) {
       console.log(`Exclude Patterns: ${options.excludePatterns.join(', ')}`);
+    }
+    if (options.includePatterns.length > 0) {
+      console.log(`Include Patterns: ${options.includePatterns.join(', ')}`);
     }
   }
   console.log(`Retry Attempts: ${options.retries}`);
@@ -336,6 +380,18 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
     const pendingUrls: string[] = [targetUrl];
     let processedCount = 0;
     const errorSummaries: ErrorSummary[] = [];
+    const runStartedAt = new Date();
+    const perPageResults: Array<{
+      url: string;
+      results: Array<{
+        resolution: string;
+        outputPath?: string;
+        success: boolean;
+        attempts: number;
+        error?: string;
+      }>;
+    }> = [];
+    let anyFailures = false;
 
     // Get the hostname and date for directory structure
     const urlObj = new URL(targetUrl);
@@ -389,7 +445,7 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
         try {
           // Use fixed 30 second timeout for Playwright
           const navigationPromise = page.goto(normalizedUrl, {
-            waitUntil: 'networkidle',
+            waitUntil: options.waitUntil,
             timeout: 30000, // Fixed Playwright timeout
           });
 
@@ -431,7 +487,7 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
                   // Navigate to the URL with timeout handling
                   try {
                     const navigationPromise = resolutionPage.goto(normalizedUrl, {
-                      waitUntil: 'networkidle',
+                      waitUntil: options.waitUntil,
                       timeout: 30000,
                     });
 
@@ -450,16 +506,22 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
                   // Set viewport for this resolution
                   await resolutionPage.setViewportSize({width, height});
 
+                  // Optional delay before screenshot
+                  if (options.delay > 0) {
+                    await new Promise((resolve) => setTimeout(resolve, options.delay));
+                  }
+
                   // Get sanitized path for the current URL
                   const url = new URL(normalizedUrl);
                   const sanitizedPath = sanitizePath(url.pathname);
+                  const sanitizedQ = sanitizeQuery(url.search);
 
                   // Generate filename
-                  const filename = `${resolutionString}-${sanitizedPath}.png`;
+                  const filename = `${resolutionString}-${sanitizedPath}${sanitizedQ ? `__${sanitizedQ}` : ''}.png`;
                   const outputPath = path.join(screenshotBaseDir, filename);
 
                   // Take screenshot
-                  await resolutionPage.screenshot({path: outputPath, fullPage: true});
+                  await resolutionPage.screenshot({path: outputPath, fullPage: options.fullPage});
 
                   return {outputPath};
                 } finally {
@@ -507,7 +569,19 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
           }
         });
 
+        perPageResults.push({
+          url: normalizedUrl,
+          results: results.map((r) => ({
+            resolution: r.resolution,
+            outputPath: r.outputPath,
+            success: r.success,
+            attempts: r.attempts,
+            error: (r as any).error,
+          })),
+        });
+
         console.log(`\nScreenshot summary: ${successCount} successful, ${failureCount} failed`);
+        if (failureCount > 0) anyFailures = true;
 
         // If crawling is enabled, extract and queue more URLs
         if (options.crawl) {
@@ -520,11 +594,14 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
             const normalizedLink = normalizeUrl(link);
             if (
               !visitedUrls.has(normalizedLink) &&
-              !isUrlExcluded(normalizedLink, options.excludePatterns)
+              !isUrlExcluded(normalizedLink, options.excludePatterns) &&
+              isUrlIncluded(normalizedLink, options.includePatterns)
             ) {
               pendingUrls.push(normalizedLink);
             } else if (isUrlExcluded(normalizedLink, options.excludePatterns)) {
               console.log(`  - Excluding URL (matches pattern): ${normalizedLink}`);
+            } else if (!isUrlIncluded(normalizedLink, options.includePatterns)) {
+              console.log(`  - Skipping URL (does not match include patterns): ${normalizedLink}`);
             }
           }
 
@@ -533,6 +610,7 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
       } catch (error: any) {
         const errorSummary = createErrorSummary(normalizedUrl, error);
         errorSummaries.push(errorSummary);
+        anyFailures = true;
 
         console.error(`Error processing ${normalizedUrl}: ${error.message}`);
         console.error(`Error type: ${errorSummary.type}`);
@@ -588,6 +666,44 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
       }
     } else {
       console.log('\n✓ No errors occurred during processing.');
+    }
+
+    // Write run manifest
+    const runFinishedAt = new Date();
+    const manifest = {
+      target: targetUrl,
+      startedAt: runStartedAt.toISOString(),
+      finishedAt: runFinishedAt.toISOString(),
+      options: {
+        browser: options.browser,
+        output: options.output,
+        crawl: options.crawl,
+        maxPages: options.maxPages,
+        timeout: options.timeout,
+        concurrency: options.concurrency,
+        retries: options.retries,
+        continueOnError: options.continueOnError,
+        waitUntil: options.waitUntil,
+        delay: options.delay,
+        fullPage: options.fullPage,
+        includePatterns: options.includePatterns,
+        excludePatterns: options.excludePatterns,
+        resolutions: parsedResolutions.map((r) => `${r.width}x${r.height}`),
+      },
+      pages: perPageResults,
+      errors: errorSummaries,
+      summary: {
+        pagesProcessed: visitedUrls.size,
+        totalErrors: errorSummaries.length,
+        anyFailures: anyFailures || errorSummaries.length > 0,
+      },
+    };
+    const manifestPath = path.join(screenshotBaseDir, 'run.json');
+    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+    console.log(`\nRun manifest written: ${manifestPath}`);
+
+    if (anyFailures || errorSummaries.length > 0) {
+      process.exitCode = 1;
     }
   } catch (error: any) {
     console.error('\n--- An Error Occurred ---');
@@ -695,7 +811,7 @@ program
     3
   )
   .option(
-    '-r, --retries <n>',
+    '-R, --retries <n>',
     'Number of retry attempts for failed screenshots (defaults to 2)',
     (value) => {
       const parsed = parseInt(value, 10);
@@ -715,11 +831,43 @@ program
     []
   )
   .option(
+    '-i, --include-pattern <pattern>',
+    'URL patterns to include when crawling (supports wildcards). If provided, only matching URLs are crawled. Repeatable.',
+    (value: string, previous: string[] = []) => previous.concat([value]),
+    []
+  )
+  .option(
     '--continue-on-error',
     'Continue processing other URLs/resolutions when errors occur (default: true)',
     true
   )
   .option('--fail-fast', 'Stop processing immediately when any error occurs', false)
+  .option<'load' | 'domcontentloaded' | 'networkidle' | 'commit'>(
+    '--wait-until <state>',
+    'Playwright navigation waitUntil state (load | domcontentloaded | networkidle | commit). Default: networkidle',
+    (value: string) => {
+      const v = value.toLowerCase();
+      const allowed = ['load', 'domcontentloaded', 'networkidle', 'commit'];
+      if (!allowed.includes(v)) {
+        throw new Error(`Invalid wait-until state. Choose from: ${allowed.join(', ')}`);
+      }
+      return v as any;
+    },
+    'networkidle'
+  )
+  .option(
+    '--delay <ms>',
+    'Delay before taking a screenshot after navigation/timeout (milliseconds). Default: 0',
+    (value) => {
+      const parsed = parseInt(value, 10);
+      if (isNaN(parsed) || parsed < 0) {
+        throw new Error('Delay must be a non-negative number');
+      }
+      return parsed;
+    },
+    0
+  )
+  .option('--no-full-page', 'Capture only the visible viewport (default is full page).')
   .action(
     async (
       url: string,
@@ -735,8 +883,12 @@ program
         concurrency: number;
         retries: number;
         excludePattern: string[];
+        includePattern: string[];
         continueOnError: boolean;
         failFast: boolean;
+        waitUntil: 'load' | 'domcontentloaded' | 'networkidle' | 'commit';
+        delay: number;
+        fullPage: boolean;
       }
     ) => {
       try {
@@ -773,7 +925,11 @@ program
           concurrency: mergedOptions.concurrency,
           retries: mergedOptions.retries,
           excludePatterns: mergedOptions.excludePattern,
+          includePatterns: mergedOptions.includePattern,
           continueOnError: mergedOptions.continueOnError,
+          waitUntil: mergedOptions.waitUntil,
+          delay: mergedOptions.delay,
+          fullPage: mergedOptions.fullPage,
         };
 
         // Basic URL validation before passing to the main function

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ interface CliOptions {
   waitUntil: 'load' | 'domcontentloaded' | 'networkidle' | 'commit';
   delay: number;
   fullPage: boolean;
+  headless: boolean;
 }
 
 interface ErrorSummary {
@@ -62,6 +63,7 @@ interface ConfigFile {
   waitUntil?: 'load' | 'domcontentloaded' | 'networkidle' | 'commit' | string;
   delay?: number;
   fullPage?: boolean;
+  headless?: boolean;
 }
 
 // --- Configuration File Support ---
@@ -147,6 +149,8 @@ function mergeConfigWithOptions(config: ConfigFile | null, cliOptions: any): any
     delay: cliOptions.delay !== 0 ? cliOptions.delay : (config.delay ?? cliOptions.delay),
     fullPage:
       typeof cliOptions.fullPage === 'boolean' ? cliOptions.fullPage : (config.fullPage ?? true),
+    headless:
+      typeof cliOptions.headless === 'boolean' ? cliOptions.headless : (config.headless ?? true),
   };
 }
 
@@ -346,6 +350,7 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
   console.log(
     `Wait Until: ${options.waitUntil}; Delay before screenshot: ${options.delay}ms; Full Page: ${options.fullPage}`
   );
+  console.log(`Headless: ${options.headless}`);
   console.log(`Crawl Mode: ${options.crawl ? 'Enabled' : 'Disabled'}`);
   if (options.crawl) {
     console.log(`Max Pages: ${options.maxPages}`);
@@ -370,7 +375,7 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
     // Launch Browser
     const browserType: BrowserType = playwright[options.browser];
     console.log(`Launching ${options.browser}...`);
-    browser = await browserType.launch();
+    browser = await browserType.launch({headless: options.headless});
     const context = await browser.newContext();
     const page = await context.newPage();
     console.log('Browser launched successfully.');
@@ -686,6 +691,7 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
         waitUntil: options.waitUntil,
         delay: options.delay,
         fullPage: options.fullPage,
+        headless: options.headless,
         includePatterns: options.includePatterns,
         excludePatterns: options.excludePatterns,
         resolutions: parsedResolutions.map((r) => `${r.width}x${r.height}`),
@@ -868,6 +874,7 @@ program
     0
   )
   .option('--no-full-page', 'Capture only the visible viewport (default is full page).')
+  .option('--no-headless', 'Run browser in headed mode (show UI).')
   .action(
     async (
       url: string,
@@ -889,6 +896,7 @@ program
         waitUntil: 'load' | 'domcontentloaded' | 'networkidle' | 'commit';
         delay: number;
         fullPage: boolean;
+        headless: boolean;
       }
     ) => {
       try {
@@ -930,6 +938,7 @@ program
           waitUntil: mergedOptions.waitUntil,
           delay: mergedOptions.delay,
           fullPage: mergedOptions.fullPage,
+          headless: mergedOptions.headless,
         };
 
         // Basic URL validation before passing to the main function

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import fs from 'fs/promises';
 import fsSync from 'fs';
 import {URL} from 'url';
 import {Resolution, parseResolution, collectResolutions, sanitizePath, normalizeUrl} from './utils';
+import os from 'os';
 
 // Define valid browser types for Playwright
 type SupportedBrowser = 'chromium' | 'firefox' | 'webkit';
@@ -20,11 +21,218 @@ interface CliOptions {
   crawl: boolean;
   maxPages: number;
   timeout: number;
+  concurrency: number;
+  retries: number;
+  excludePatterns: string[];
+  continueOnError: boolean;
+}
+
+interface ErrorSummary {
+  url: string;
+  error: string;
+  type: 'navigation' | 'screenshot' | 'linkExtraction' | 'fileSystem' | 'unknown';
+  timestamp: string;
+}
+
+interface ConfigFile {
+  resolutions?: string[];
+  output?: string;
+  browser?: SupportedBrowser;
+  crawl?: boolean;
+  maxPages?: number;
+  timeout?: number;
+  concurrency?: number;
+  retries?: number;
+  continueOnError?: boolean;
+  desktop?: boolean;
+  mobile?: boolean;
+  excludePatterns?: string[];
+}
+
+// --- Configuration File Support ---
+
+// Function to find and load configuration file
+async function loadConfigFile(): Promise<ConfigFile | null> {
+  const configFilenames = ['.crawlsnaprc.json', '.crawlsnaprc'];
+  const searchPaths = [
+    process.cwd(), // Current directory
+    os.homedir(), // Home directory
+  ];
+
+  for (const searchPath of searchPaths) {
+    for (const filename of configFilenames) {
+      const configPath = path.join(searchPath, filename);
+      try {
+        const configContent = await fs.readFile(configPath, 'utf8');
+        const config = JSON.parse(configContent) as ConfigFile;
+
+        // Validate browser if specified
+        if (config.browser && !supportedBrowsers.includes(config.browser)) {
+          console.warn(`Invalid browser "${config.browser}" in ${configPath}. Using default.`);
+          delete config.browser;
+        }
+
+        console.log(`Using configuration from: ${configPath}`);
+        return config;
+      } catch (error: any) {
+        // File doesn't exist or is invalid, continue searching
+        if (error.code !== 'ENOENT') {
+          console.warn(`Warning: Could not parse config file ${configPath}: ${error.message}`);
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+// Function to merge config file with CLI options (CLI takes precedence)
+function mergeConfigWithOptions(config: ConfigFile | null, cliOptions: any): any {
+  if (!config) return cliOptions;
+
+  // Merge exclude patterns from both CLI and config
+  const excludePatterns = [...(cliOptions.excludePattern || []), ...(config.excludePatterns || [])];
+
+  return {
+    resolution:
+      cliOptions.resolution.length === 1 &&
+      cliOptions.resolution[0].width === 1920 &&
+      cliOptions.resolution[0].height === 1080
+        ? config.resolutions?.map(parseResolution) || cliOptions.resolution // Use config if CLI has default
+        : cliOptions.resolution, // Use CLI if custom resolutions provided
+    output: cliOptions.output !== '.' ? cliOptions.output : config.output || cliOptions.output,
+    browser:
+      cliOptions.browser !== 'chromium' ? cliOptions.browser : config.browser || cliOptions.browser,
+    crawl: cliOptions.crawl || config.crawl || false,
+    maxPages:
+      cliOptions.maxPages !== 50 ? cliOptions.maxPages : config.maxPages || cliOptions.maxPages,
+    timeout:
+      cliOptions.timeout !== 5000 ? cliOptions.timeout : config.timeout || cliOptions.timeout,
+    concurrency:
+      cliOptions.concurrency !== 3
+        ? cliOptions.concurrency
+        : config.concurrency || cliOptions.concurrency,
+    retries: cliOptions.retries !== 2 ? cliOptions.retries : (config.retries ?? cliOptions.retries),
+    excludePattern: excludePatterns,
+    continueOnError: cliOptions.failFast
+      ? false
+      : (cliOptions.continueOnError ?? config.continueOnError ?? true),
+    desktop: cliOptions.desktop || config.desktop || false,
+    mobile: cliOptions.mobile || config.mobile || false,
+  };
+}
+
+// Function to check if a URL matches any exclusion pattern
+function isUrlExcluded(url: string, excludePatterns: string[]): boolean {
+  if (excludePatterns.length === 0) return false;
+
+  return excludePatterns.some((pattern) => {
+    // Convert glob-like pattern to regex
+    // Replace * with .* and escape other regex special characters
+    const regexPattern = pattern
+      .replace(/[.+^${}()|[\]\\?]/g, '\\$&') // Escape regex special chars except *
+      .replace(/\*/g, '.*'); // Convert * to .*
+
+    const regex = new RegExp(`^${regexPattern}$`, 'i'); // Case insensitive
+    return regex.test(url);
+  });
+}
+
+// Function to classify errors for better reporting
+function classifyError(error: any): ErrorSummary['type'] {
+  const errorMessage = error?.message?.toLowerCase() || '';
+
+  if (error?.name === 'TimeoutError' || errorMessage.includes('timeout')) {
+    return 'navigation';
+  }
+  if (errorMessage.includes('screenshot') || errorMessage.includes('page.screenshot')) {
+    return 'screenshot';
+  }
+  if (
+    errorMessage.includes('enoent') ||
+    errorMessage.includes('permission') ||
+    errorMessage.includes('mkdir')
+  ) {
+    return 'fileSystem';
+  }
+  if (
+    errorMessage.includes('network') ||
+    errorMessage.includes('net::') ||
+    errorMessage.includes('connection')
+  ) {
+    return 'navigation';
+  }
+  if (errorMessage.includes('evaluate') || errorMessage.includes('link')) {
+    return 'linkExtraction';
+  }
+
+  return 'unknown';
+}
+
+// Function to create error summary
+function createErrorSummary(url: string, error: any): ErrorSummary {
+  return {
+    url,
+    error: error?.message || String(error),
+    type: classifyError(error),
+    timestamp: new Date().toISOString(),
+  };
 }
 
 // --- Main Logic ---
 
-// This function is no longer needed as its functionality has been inlined into runScreenshotter
+// Helper function to limit concurrency using a semaphore-like approach
+async function limitConcurrency<T>(tasks: (() => Promise<T>)[], limit: number): Promise<T[]> {
+  const results: T[] = [];
+  const executing: Promise<void>[] = [];
+
+  for (const task of tasks) {
+    const promise = task().then((result) => {
+      results.push(result);
+    });
+
+    executing.push(promise);
+
+    if (executing.length >= limit) {
+      await Promise.race(executing);
+      executing.splice(
+        executing.findIndex((p) => p === promise),
+        1
+      );
+    }
+  }
+
+  await Promise.all(executing);
+  return results;
+}
+
+// Helper function to retry operations with exponential backoff
+async function retryWithBackoff<T>(
+  operation: () => Promise<T>,
+  maxRetries: number,
+  baseDelay: number = 1000
+): Promise<T> {
+  let lastError: Error = new Error('No attempts made');
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await operation();
+    } catch (error: any) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+
+      if (attempt === maxRetries) {
+        throw lastError;
+      }
+
+      // Exponential backoff: 1s, 2s, 4s, 8s...
+      const delay = baseDelay * Math.pow(2, attempt);
+      console.log(`  Retry ${attempt + 1}/${maxRetries} after ${delay}ms...`);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+}
 
 async function extractLinks(page: Page, baseUrl: string): Promise<string[]> {
   const url = new URL(baseUrl);
@@ -100,7 +308,12 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
   console.log(`Crawl Mode: ${options.crawl ? 'Enabled' : 'Disabled'}`);
   if (options.crawl) {
     console.log(`Max Pages: ${options.maxPages}`);
+    if (options.excludePatterns.length > 0) {
+      console.log(`Exclude Patterns: ${options.excludePatterns.join(', ')}`);
+    }
   }
+  console.log(`Retry Attempts: ${options.retries}`);
+  console.log(`Concurrency: ${options.concurrency}`);
   console.log('Resolutions to capture:');
   parsedResolutions.forEach((res) => console.log(`- ${res.width}x${res.height}`));
   console.log('---');
@@ -122,6 +335,7 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
     const visitedUrls = new Set<string>();
     const pendingUrls: string[] = [targetUrl];
     let processedCount = 0;
+    const errorSummaries: ErrorSummary[] = [];
 
     // Get the hostname and date for directory structure
     const urlObj = new URL(targetUrl);
@@ -197,28 +411,103 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
           }
         }
 
-        // Process each resolution for the current URL without re-navigating
-        for (const resolution of parsedResolutions) {
+        // Process all resolutions with controlled concurrency for better performance
+        console.log(
+          `\nProcessing ${parsedResolutions.length} resolutions (max ${options.concurrency} concurrent)...`
+        );
+
+        const screenshotTasks = parsedResolutions.map((resolution) => {
           const {width, height} = resolution;
           const resolutionString = `${width}x${height}`;
-          console.log(`\nProcessing resolution: ${resolutionString}`);
 
-          // Set viewport for the current resolution
-          await page.setViewportSize({width, height});
+          return async () => {
+            try {
+              // Wrap screenshot operation in retry logic
+              const result = await retryWithBackoff(async () => {
+                // Create a new page for each resolution to avoid conflicts
+                const resolutionPage = await context.newPage();
 
-          // Get sanitized path for the current URL
-          const url = new URL(normalizedUrl);
-          const sanitizedPath = sanitizePath(url.pathname);
+                try {
+                  // Navigate to the URL with timeout handling
+                  try {
+                    const navigationPromise = resolutionPage.goto(normalizedUrl, {
+                      waitUntil: 'networkidle',
+                      timeout: 30000,
+                    });
 
-          // Generate filename
-          const filename = `${resolutionString}-${sanitizedPath}.png`;
-          const outputPath = path.join(screenshotBaseDir, filename);
+                    // Race between networkidle and user-specified timeout
+                    await Promise.race([
+                      navigationPromise,
+                      new Promise((resolve) => setTimeout(resolve, options.timeout)),
+                    ]);
+                  } catch (error: any) {
+                    if (error.name !== 'TimeoutError') {
+                      throw error;
+                    }
+                    // Continue with screenshot if timeout
+                  }
 
-          // Take screenshot
-          console.log(`- Taking full page screenshot...`);
-          await page.screenshot({path: outputPath, fullPage: true});
-          console.log(`- Screenshot saved: ${outputPath}`);
-        }
+                  // Set viewport for this resolution
+                  await resolutionPage.setViewportSize({width, height});
+
+                  // Get sanitized path for the current URL
+                  const url = new URL(normalizedUrl);
+                  const sanitizedPath = sanitizePath(url.pathname);
+
+                  // Generate filename
+                  const filename = `${resolutionString}-${sanitizedPath}.png`;
+                  const outputPath = path.join(screenshotBaseDir, filename);
+
+                  // Take screenshot
+                  await resolutionPage.screenshot({path: outputPath, fullPage: true});
+
+                  return {outputPath};
+                } finally {
+                  // Always close the page to free memory
+                  await resolutionPage.close();
+                }
+              }, options.retries);
+
+              return {
+                success: true,
+                resolution: resolutionString,
+                outputPath: result.outputPath,
+                attempts: options.retries + 1,
+              };
+            } catch (error: any) {
+              return {
+                success: false,
+                resolution: resolutionString,
+                error: error.message,
+                attempts: options.retries + 1,
+              };
+            }
+          };
+        });
+
+        // Execute tasks with concurrency limit
+        const results = await limitConcurrency(screenshotTasks, options.concurrency);
+
+        // Process results and report status
+        let successCount = 0;
+        let failureCount = 0;
+
+        results.forEach((result) => {
+          if (result.success) {
+            const retryInfo = result.attempts > 1 ? ` (after ${result.attempts - 1} retries)` : '';
+            console.log(
+              `✓ ${result.resolution} screenshot saved: ${result.outputPath}${retryInfo}`
+            );
+            successCount++;
+          } else {
+            console.error(
+              `✗ ${result.resolution} failed after ${result.attempts} attempts: ${result.error}`
+            );
+            failureCount++;
+          }
+        });
+
+        console.log(`\nScreenshot summary: ${successCount} successful, ${failureCount} failed`);
 
         // If crawling is enabled, extract and queue more URLs
         if (options.crawl) {
@@ -226,20 +515,34 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
           const links = await extractLinks(page, normalizedUrl);
           console.log(`- Found ${links.length} links.`);
 
-          // Add new links to pending queue if not already visited (normalize URLs)
+          // Add new links to pending queue if not already visited and not excluded
           for (const link of links) {
             const normalizedLink = normalizeUrl(link);
-            if (!visitedUrls.has(normalizedLink)) {
+            if (
+              !visitedUrls.has(normalizedLink) &&
+              !isUrlExcluded(normalizedLink, options.excludePatterns)
+            ) {
               pendingUrls.push(normalizedLink);
+            } else if (isUrlExcluded(normalizedLink, options.excludePatterns)) {
+              console.log(`  - Excluding URL (matches pattern): ${normalizedLink}`);
             }
           }
 
           console.log(`- Queue size: ${pendingUrls.length}, Visited: ${visitedUrls.size}`);
         }
       } catch (error: any) {
+        const errorSummary = createErrorSummary(normalizedUrl, error);
+        errorSummaries.push(errorSummary);
+
         console.error(`Error processing ${normalizedUrl}: ${error.message}`);
-        console.error(`Skipping to next URL...`);
-        // Continue with next URL instead of aborting everything
+        console.error(`Error type: ${errorSummary.type}`);
+
+        if (!options.continueOnError) {
+          console.error('Stopping due to --fail-fast option.');
+          throw error;
+        }
+
+        console.error('Continuing to next URL...');
       }
     }
 
@@ -250,6 +553,41 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
           `Reached maximum page limit of ${options.maxPages}. ${pendingUrls.length} URLs not processed.`
         );
       }
+    }
+
+    // Report error summary if any errors occurred
+    if (errorSummaries.length > 0) {
+      console.log(`\n--- Error Summary ---`);
+      console.log(`Total errors: ${errorSummaries.length}`);
+
+      // Group errors by type
+      const errorsByType = errorSummaries.reduce(
+        (acc, error) => {
+          acc[error.type] = (acc[error.type] || 0) + 1;
+          return acc;
+        },
+        {} as Record<string, number>
+      );
+
+      console.log('Error breakdown by type:');
+      Object.entries(errorsByType).forEach(([type, count]) => {
+        console.log(`  ${type}: ${count}`);
+      });
+
+      if (errorSummaries.length <= 10) {
+        console.log('\nDetailed errors:');
+        errorSummaries.forEach((error, index) => {
+          console.log(`  ${index + 1}. [${error.type}] ${error.url}: ${error.error}`);
+        });
+      } else {
+        console.log('\nFirst 10 errors (use --continue-on-error=false to stop on first error):');
+        errorSummaries.slice(0, 10).forEach((error, index) => {
+          console.log(`  ${index + 1}. [${error.type}] ${error.url}: ${error.error}`);
+        });
+        console.log(`  ... and ${errorSummaries.length - 10} more errors`);
+      }
+    } else {
+      console.log('\n✓ No errors occurred during processing.');
     }
   } catch (error: any) {
     console.error('\n--- An Error Occurred ---');
@@ -344,6 +682,44 @@ program
     },
     5000
   )
+  .option(
+    '--concurrency <n>',
+    'Maximum number of concurrent screenshot operations (defaults to 3)',
+    (value) => {
+      const parsed = parseInt(value, 10);
+      if (isNaN(parsed) || parsed <= 0) {
+        throw new Error('Concurrency must be a positive number');
+      }
+      return parsed;
+    },
+    3
+  )
+  .option(
+    '-r, --retries <n>',
+    'Number of retry attempts for failed screenshots (defaults to 2)',
+    (value) => {
+      const parsed = parseInt(value, 10);
+      if (isNaN(parsed) || parsed < 0) {
+        throw new Error('Retries must be a non-negative number');
+      }
+      return parsed;
+    },
+    2
+  )
+  .option(
+    '-x, --exclude-pattern <pattern>',
+    'URL patterns to exclude from crawling (supports wildcards like */admin/*). Repeatable.',
+    (value: string, previous: string[] = []) => {
+      return previous.concat([value]);
+    },
+    []
+  )
+  .option(
+    '--continue-on-error',
+    'Continue processing other URLs/resolutions when errors occur (default: true)',
+    true
+  )
+  .option('--fail-fast', 'Stop processing immediately when any error occurs', false)
   .action(
     async (
       url: string,
@@ -356,35 +732,50 @@ program
         desktop: boolean;
         mobile: boolean;
         timeout: number;
+        concurrency: number;
+        retries: number;
+        excludePattern: string[];
+        continueOnError: boolean;
+        failFast: boolean;
       }
     ) => {
-      // Handle device presets
-      let resolutions = [...options.resolution]; // Start with custom resolutions
-
-      if (options.desktop) {
-        resolutions = [...resolutions, ...devicePresets.desktop];
-      }
-
-      if (options.mobile) {
-        resolutions = [...resolutions, ...devicePresets.mobile];
-      }
-
-      // Remove duplicates (based on width and height)
-      const uniqueResolutions = Array.from(
-        new Map(resolutions.map((r) => [`${r.width}x${r.height}`, r])).values()
-      );
-
-      // Map commander's options to our interface
-      const mappedOptions: CliOptions = {
-        resolutions: uniqueResolutions.map((r) => `${r.width}x${r.height}`),
-        output: options.output,
-        browser: options.browser,
-        crawl: options.crawl,
-        maxPages: options.maxPages,
-        timeout: options.timeout,
-      };
-
       try {
+        // Load configuration file first
+        const configFile = await loadConfigFile();
+
+        // Merge config file with CLI options (CLI takes precedence)
+        const mergedOptions = mergeConfigWithOptions(configFile, options);
+
+        // Handle device presets
+        let resolutions = [...mergedOptions.resolution]; // Start with merged resolutions
+
+        if (mergedOptions.desktop) {
+          resolutions = [...resolutions, ...devicePresets.desktop];
+        }
+
+        if (mergedOptions.mobile) {
+          resolutions = [...resolutions, ...devicePresets.mobile];
+        }
+
+        // Remove duplicates (based on width and height)
+        const uniqueResolutions = Array.from(
+          new Map(resolutions.map((r) => [`${r.width}x${r.height}`, r])).values()
+        );
+
+        // Map merged options to our interface
+        const mappedOptions: CliOptions = {
+          resolutions: uniqueResolutions.map((r) => `${r.width}x${r.height}`),
+          output: mergedOptions.output,
+          browser: mergedOptions.browser,
+          crawl: mergedOptions.crawl,
+          maxPages: mergedOptions.maxPages,
+          timeout: mergedOptions.timeout,
+          concurrency: mergedOptions.concurrency,
+          retries: mergedOptions.retries,
+          excludePatterns: mergedOptions.excludePattern,
+          continueOnError: mergedOptions.continueOnError,
+        };
+
         // Basic URL validation before passing to the main function
         new URL(url);
         await runScreenshotter(url, mappedOptions);

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,63 +1,69 @@
-import { describe, it, expect } from 'vitest';
-import { parseResolution, sanitizePath, normalizeUrl } from './utils';
+import {describe, it, expect} from 'vitest';
+import {parseResolution, sanitizePath, normalizeUrl} from './utils';
 
 describe('parseResolution', () => {
-    it('parses valid resolution strings', () => {
-        expect(parseResolution('1920x1080')).toEqual({ width: 1920, height: 1080 });
-        expect(parseResolution('800x600')).toEqual({ width: 800, height: 600 });
-        expect(parseResolution('320x240')).toEqual({ width: 320, height: 240 });
-    });
+  it('parses valid resolution strings', () => {
+    expect(parseResolution('1920x1080')).toEqual({width: 1920, height: 1080});
+    expect(parseResolution('800x600')).toEqual({width: 800, height: 600});
+    expect(parseResolution('320x240')).toEqual({width: 320, height: 240});
+  });
 
-    it('throws error for invalid resolution format', () => {
-        expect(() => parseResolution('1920')).toThrow('Invalid resolution format');
-        expect(() => parseResolution('1920x')).toThrow('Invalid resolution dimensions: "1920x". Width and height must be positive numbers.');
-        expect(() => parseResolution('x1080')).toThrow('Invalid resolution dimensions: "x1080". Width and height must be positive numbers.');
-        expect(() => parseResolution('1920-1080')).toThrow('Invalid resolution format');
-    });
+  it('throws error for invalid resolution format', () => {
+    expect(() => parseResolution('1920')).toThrow('Invalid resolution format');
+    expect(() => parseResolution('1920x')).toThrow(
+      'Invalid resolution dimensions: "1920x". Width and height must be positive numbers.'
+    );
+    expect(() => parseResolution('x1080')).toThrow(
+      'Invalid resolution dimensions: "x1080". Width and height must be positive numbers.'
+    );
+    expect(() => parseResolution('1920-1080')).toThrow('Invalid resolution format');
+  });
 
-    it('throws error for invalid dimensions', () => {
-        expect(() => parseResolution('0x1080')).toThrow('Invalid resolution dimensions');
-        expect(() => parseResolution('1920x0')).toThrow('Invalid resolution dimensions');
-        expect(() => parseResolution('-1920x1080')).toThrow('Invalid resolution dimensions');
-        expect(() => parseResolution('1920x-1080')).toThrow('Invalid resolution dimensions');
-        expect(() => parseResolution('abcx1080')).toThrow('Invalid resolution dimensions');
-        expect(() => parseResolution('1920xabc')).toThrow('Invalid resolution dimensions');
-    });
+  it('throws error for invalid dimensions', () => {
+    expect(() => parseResolution('0x1080')).toThrow('Invalid resolution dimensions');
+    expect(() => parseResolution('1920x0')).toThrow('Invalid resolution dimensions');
+    expect(() => parseResolution('-1920x1080')).toThrow('Invalid resolution dimensions');
+    expect(() => parseResolution('1920x-1080')).toThrow('Invalid resolution dimensions');
+    expect(() => parseResolution('abcx1080')).toThrow('Invalid resolution dimensions');
+    expect(() => parseResolution('1920xabc')).toThrow('Invalid resolution dimensions');
+  });
 });
 
 describe('sanitizePath', () => {
-    it('sanitizes simple paths', () => {
-        expect(sanitizePath('/about')).toBe('about');
-        expect(sanitizePath('/about/')).toBe('about');
-        expect(sanitizePath('/about/us')).toBe('about-us');
-    });
+  it('sanitizes simple paths', () => {
+    expect(sanitizePath('/about')).toBe('about');
+    expect(sanitizePath('/about/')).toBe('about');
+    expect(sanitizePath('/about/us')).toBe('about-us');
+  });
 
-    it('handles special characters', () => {
-        expect(sanitizePath('/product?id=123')).toBe('product_id_123');
-        expect(sanitizePath('/search?q=term&page=2')).toBe('search_q_term_page_2');
-    });
+  it('handles special characters', () => {
+    expect(sanitizePath('/product?id=123')).toBe('product_id_123');
+    expect(sanitizePath('/search?q=term&page=2')).toBe('search_q_term_page_2');
+  });
 
-    it('handles root path', () => {
-        expect(sanitizePath('/')).toBe('root');
-        expect(sanitizePath('')).toBe('root');
-    });
+  it('handles root path', () => {
+    expect(sanitizePath('/')).toBe('root');
+    expect(sanitizePath('')).toBe('root');
+  });
 });
 
 describe('normalizeUrl', () => {
-    it('removes trailing slashes from paths', () => {
-        expect(normalizeUrl('https://example.com/')).toBe('https://example.com/');
-        expect(normalizeUrl('https://example.com/about/')).toBe('https://example.com/about');
-    });
+  it('removes trailing slashes from paths', () => {
+    expect(normalizeUrl('https://example.com/')).toBe('https://example.com/');
+    expect(normalizeUrl('https://example.com/about/')).toBe('https://example.com/about');
+  });
 
-    it('preserves URLs without trailing slashes', () => {
-        expect(normalizeUrl('https://example.com/about')).toBe('https://example.com/about');
-    });
+  it('preserves URLs without trailing slashes', () => {
+    expect(normalizeUrl('https://example.com/about')).toBe('https://example.com/about');
+  });
 
-    it('preserves query parameters', () => {
-        expect(normalizeUrl('https://example.com/search?q=test')).toBe('https://example.com/search?q=test');
-    });
+  it('preserves query parameters', () => {
+    expect(normalizeUrl('https://example.com/search?q=test')).toBe(
+      'https://example.com/search?q=test'
+    );
+  });
 
-    it('returns original for invalid URLs', () => {
-        expect(normalizeUrl('invalid-url')).toBe('invalid-url');
-    });
+  it('returns original for invalid URLs', () => {
+    expect(normalizeUrl('invalid-url')).toBe('invalid-url');
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,3 +67,16 @@ export function normalizeUrl(url: string): string {
     return url; // Return original if invalid
   }
 }
+
+// Sanitize the query string (without leading '?') for safe filenames
+// Example: '?q=test&page=2' -> 'q_test_page_2'
+export function sanitizeQuery(query: string): string {
+  if (!query) return '';
+  const trimmed = query.startsWith('?') ? query.slice(1) : query;
+  if (trimmed.length === 0) return '';
+  // Replace non-alphanumeric with underscore, collapse repeats
+  return trimmed
+    .replace(/[^a-zA-Z0-9]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}

--- a/static/dev/admin/dashboard.html
+++ b/static/dev/admin/dashboard.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin Dashboard</title>
+  </head>
+  <body>
+    <h1>Admin Dashboard</h1>
+    <p>Restricted area placeholder.</p>
+    <p><a href="../index.html">Back</a></p>
+  </body>
+  </html>
+

--- a/static/dev/index.html
+++ b/static/dev/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>crawl-n-snap dev page</title>
+    <style>
+      body { font-family: -apple-system, system-ui, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, sans-serif; margin: 2rem; }
+      .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; }
+      .card { border: 1px solid #ddd; border-radius: 8px; padding: 1rem; }
+      a { color: #0b6; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+    </style>
+  </head>
+  <body>
+    <h1>crawl-n-snap Dev Page</h1>
+    <p>This page is for local screenshots during development.</p>
+
+    <div class="grid">
+      <div class="card">
+        <h3>Root</h3>
+        <p><a href="/static/dev/">/static/dev/</a></p>
+      </div>
+      <div class="card">
+        <h3>Products</h3>
+        <ul>
+          <li><a href="./product.html?id=1">Product 1</a></li>
+          <li><a href="./product.html?id=2">Product 2</a></li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>Admin</h3>
+        <p><a href="./admin/dashboard.html">Admin Dashboard</a></p>
+      </div>
+    </div>
+
+    <p>
+      Try include/exclude patterns:
+      <code>-i "*product*" -x "*admin*"</code>
+    </p>
+  </body>
+  </html>
+

--- a/static/dev/product.html
+++ b/static/dev/product.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Product</title>
+  </head>
+  <body>
+    <h1>Product Page</h1>
+    <p id="desc">This is a mock product page.</p>
+    <p><a href="./index.html">Back</a></p>
+  </body>
+  </html>
+

--- a/ui/eslint.config.mjs
+++ b/ui/eslint.config.mjs
@@ -1,0 +1,29 @@
+import { defineConfig, globalIgnores } from 'eslint/config';
+import tsParser from '@typescript-eslint/parser';
+import typescriptEslint from '@typescript-eslint/eslint-plugin';
+import js from '@eslint/js';
+import globals from 'globals';
+
+export default defineConfig([
+  globalIgnores(['dist/**/*', 'node_modules/**/*']),
+  {
+    name: 'ui/ts-react',
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      parserOptions: { ecmaFeatures: { jsx: true } },
+      globals: { ...globals.browser },
+    },
+    plugins: {
+      '@typescript-eslint': typescriptEslint,
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...typescriptEslint.configs.recommended.rules,
+      'no-console': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+    },
+  },
+]);

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Crawl‑n‑Snap UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+  </html>
+

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "crawl-n-snap-ui",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.2",
+    "vite": "^5.4.8",
+    "typescript": "^5.6.3"
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.2",
+    "@types/react": "^18.3.1",
     "vite": "^5.4.8",
     "typescript": "^5.6.3"
   }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@types/react':
+        specifier: ^18.3.1
+        version: 18.3.24
       '@vitejs/plugin-react':
         specifier: ^4.3.2
         version: 4.7.0(vite@5.4.19)
@@ -387,6 +390,12 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react@18.3.24':
+    resolution: {integrity: sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==}
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -403,6 +412,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -836,6 +848,13 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react@18.3.24':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.1.3
+
   '@vitejs/plugin-react@4.7.0(vite@5.4.19)':
     dependencies:
       '@babel/core': 7.28.4
@@ -858,6 +877,8 @@ snapshots:
   caniuse-lite@1.0.30001741: {}
 
   convert-source-map@2.0.0: {}
+
+  csstype@3.1.3: {}
 
   debug@4.4.1:
     dependencies:

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -1,0 +1,992 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@vitejs/plugin-react':
+        specifier: ^4.3.2
+        version: 4.7.0(vite@5.4.19)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.2
+      vite:
+        specifier: ^5.4.8
+        version: 5.4.19
+
+packages:
+
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.28.4':
+    resolution: {integrity: sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.28.4':
+    resolution: {integrity: sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.28.3':
+    resolution: {integrity: sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.27.2':
+    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.27.1':
+    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.3':
+    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.27.1':
+    resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.28.4':
+    resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.28.4':
+    resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.27.2':
+    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.28.4':
+    resolution: {integrity: sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.4':
+    resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.30':
+    resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.50.0':
+    resolution: {integrity: sha512-lVgpeQyy4fWN5QYebtW4buT/4kn4p4IJ+kDNB4uYNT5b8c8DLJDg6titg20NIg7E8RWwdWZORW6vUFfrLyG3KQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.50.0':
+    resolution: {integrity: sha512-2O73dR4Dc9bp+wSYhviP6sDziurB5/HCym7xILKifWdE9UsOe2FtNcM+I4xZjKrfLJnq5UR8k9riB87gauiQtw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.50.0':
+    resolution: {integrity: sha512-vwSXQN8T4sKf1RHr1F0s98Pf8UPz7pS6P3LG9NSmuw0TVh7EmaE+5Ny7hJOZ0M2yuTctEsHHRTMi2wuHkdS6Hg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.50.0':
+    resolution: {integrity: sha512-cQp/WG8HE7BCGyFVuzUg0FNmupxC+EPZEwWu2FCGGw5WDT1o2/YlENbm5e9SMvfDFR6FRhVCBePLqj0o8MN7Vw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.50.0':
+    resolution: {integrity: sha512-UR1uTJFU/p801DvvBbtDD7z9mQL8J80xB0bR7DqW7UGQHRm/OaKzp4is7sQSdbt2pjjSS72eAtRh43hNduTnnQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.50.0':
+    resolution: {integrity: sha512-G/DKyS6PK0dD0+VEzH/6n/hWDNPDZSMBmqsElWnCRGrYOb2jC0VSupp7UAHHQ4+QILwkxSMaYIbQ72dktp8pKA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.50.0':
+    resolution: {integrity: sha512-u72Mzc6jyJwKjJbZZcIYmd9bumJu7KNmHYdue43vT1rXPm2rITwmPWF0mmPzLm9/vJWxIRbao/jrQmxTO0Sm9w==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.50.0':
+    resolution: {integrity: sha512-S4UefYdV0tnynDJV1mdkNawp0E5Qm2MtSs330IyHgaccOFrwqsvgigUD29uT+B/70PDY1eQ3t40+xf6wIvXJyg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.50.0':
+    resolution: {integrity: sha512-1EhkSvUQXJsIhk4msxP5nNAUWoB4MFDHhtc4gAYvnqoHlaL9V3F37pNHabndawsfy/Tp7BPiy/aSa6XBYbaD1g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.50.0':
+    resolution: {integrity: sha512-EtBDIZuDtVg75xIPIK1l5vCXNNCIRM0OBPUG+tbApDuJAy9mKago6QxX+tfMzbCI6tXEhMuZuN1+CU8iDW+0UQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.50.0':
+    resolution: {integrity: sha512-BGYSwJdMP0hT5CCmljuSNx7+k+0upweM2M4YGfFBjnFSZMHOLYR0gEEj/dxyYJ6Zc6AiSeaBY8dWOa11GF/ppQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.50.0':
+    resolution: {integrity: sha512-I1gSMzkVe1KzAxKAroCJL30hA4DqSi+wGc5gviD0y3IL/VkvcnAqwBf4RHXHyvH66YVHxpKO8ojrgc4SrWAnLg==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.50.0':
+    resolution: {integrity: sha512-bSbWlY3jZo7molh4tc5dKfeSxkqnf48UsLqYbUhnkdnfgZjgufLS/NTA8PcP/dnvct5CCdNkABJ56CbclMRYCA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.50.0':
+    resolution: {integrity: sha512-LSXSGumSURzEQLT2e4sFqFOv3LWZsEF8FK7AAv9zHZNDdMnUPYH3t8ZlaeYYZyTXnsob3htwTKeWtBIkPV27iQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.50.0':
+    resolution: {integrity: sha512-CxRKyakfDrsLXiCyucVfVWVoaPA4oFSpPpDwlMcDFQvrv3XY6KEzMtMZrA+e/goC8xxp2WSOxHQubP8fPmmjOQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.50.0':
+    resolution: {integrity: sha512-8PrJJA7/VU8ToHVEPu14FzuSAqVKyo5gg/J8xUerMbyNkWkO9j2ExBho/68RnJsMGNJq4zH114iAttgm7BZVkA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.50.0':
+    resolution: {integrity: sha512-SkE6YQp+CzpyOrbw7Oc4MgXFvTw2UIBElvAvLCo230pyxOLmYwRPwZ/L5lBe/VW/qT1ZgND9wJfOsdy0XptRvw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.50.0':
+    resolution: {integrity: sha512-PZkNLPfvXeIOgJWA804zjSFH7fARBBCpCXxgkGDRjjAhRLOR8o0IGS01ykh5GYfod4c2yiiREuDM8iZ+pVsT+Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.50.0':
+    resolution: {integrity: sha512-q7cIIdFvWQoaCbLDUyUc8YfR3Jh2xx3unO8Dn6/TTogKjfwrax9SyfmGGK6cQhKtjePI7jRfd7iRYcxYs93esg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.50.0':
+    resolution: {integrity: sha512-XzNOVg/YnDOmFdDKcxxK410PrcbcqZkBmz+0FicpW5jtjKQxcW1BZJEQOF0NJa6JO7CZhett8GEtRN/wYLYJuw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.50.0':
+    resolution: {integrity: sha512-xMmiWRR8sp72Zqwjgtf3QbZfF1wdh8X2ABu3EaozvZcyHJeU0r+XAnXdKgs4cCAp6ORoYoCygipYP1mjmbjrsg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  browserslist@4.25.4:
+    resolution: {integrity: sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  caniuse-lite@1.0.30001741:
+    resolution: {integrity: sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  debug@4.4.1:
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  electron-to-chromium@1.5.214:
+    resolution: {integrity: sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.20:
+    resolution: {integrity: sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.50.0:
+    resolution: {integrity: sha512-/Zl4D8zPifNmyGzJS+3kVoyXeDeT/GrsJM94sACNg9RtUE0hrHa1bNPtRSrfHTMH5HjRzce6K7rlTh3Khiw+pw==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  update-browserslist-db@1.1.3:
+    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite@5.4.19:
+    resolution: {integrity: sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+snapshots:
+
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.27.1
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.28.4': {}
+
+  '@babel/core@7.28.4':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.3
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.4)
+      '@babel/helpers': 7.28.4
+      '@babel/parser': 7.28.4
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.28.4
+      '@babel/types': 7.28.4
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.1
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.28.3':
+    dependencies:
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.30
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.27.2':
+    dependencies:
+      '@babel/compat-data': 7.28.4
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.25.4
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.28.4
+      '@babel/types': 7.28.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/traverse': 7.28.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.27.1': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.28.4':
+    dependencies:
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.4
+
+  '@babel/parser@7.28.4':
+    dependencies:
+      '@babel/types': 7.28.4
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/template@7.27.2':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+
+  '@babel/traverse@7.28.4':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.3
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.28.4
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.4
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.28.4':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.30
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.30
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.30':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.50.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.50.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.50.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.50.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.50.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.50.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.50.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.50.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.50.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.50.0':
+    optional: true
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.50.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.50.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.50.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.50.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.50.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.50.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.50.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.50.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.50.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.50.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.50.0':
+    optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.28.4
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.4
+
+  '@types/estree@1.0.8': {}
+
+  '@vitejs/plugin-react@4.7.0(vite@5.4.19)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.4)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 5.4.19
+    transitivePeerDependencies:
+      - supports-color
+
+  browserslist@4.25.4:
+    dependencies:
+      caniuse-lite: 1.0.30001741
+      electron-to-chromium: 1.5.214
+      node-releases: 2.0.20
+      update-browserslist-db: 1.1.3(browserslist@4.25.4)
+
+  caniuse-lite@1.0.30001741: {}
+
+  convert-source-map@2.0.0: {}
+
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
+  electron-to-chromium@1.5.214: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  escalade@3.2.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  node-releases@2.0.20: {}
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-refresh@0.17.0: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
+  rollup@4.50.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.50.0
+      '@rollup/rollup-android-arm64': 4.50.0
+      '@rollup/rollup-darwin-arm64': 4.50.0
+      '@rollup/rollup-darwin-x64': 4.50.0
+      '@rollup/rollup-freebsd-arm64': 4.50.0
+      '@rollup/rollup-freebsd-x64': 4.50.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.50.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.50.0
+      '@rollup/rollup-linux-arm64-gnu': 4.50.0
+      '@rollup/rollup-linux-arm64-musl': 4.50.0
+      '@rollup/rollup-linux-loongarch64-gnu': 4.50.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.50.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.50.0
+      '@rollup/rollup-linux-riscv64-musl': 4.50.0
+      '@rollup/rollup-linux-s390x-gnu': 4.50.0
+      '@rollup/rollup-linux-x64-gnu': 4.50.0
+      '@rollup/rollup-linux-x64-musl': 4.50.0
+      '@rollup/rollup-openharmony-arm64': 4.50.0
+      '@rollup/rollup-win32-arm64-msvc': 4.50.0
+      '@rollup/rollup-win32-ia32-msvc': 4.50.0
+      '@rollup/rollup-win32-x64-msvc': 4.50.0
+      fsevents: 2.3.3
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  semver@6.3.1: {}
+
+  source-map-js@1.2.1: {}
+
+  typescript@5.9.2: {}
+
+  update-browserslist-db@1.1.3(browserslist@4.25.4):
+    dependencies:
+      browserslist: 4.25.4
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite@5.4.19:
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.50.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  yallist@3.1.1: {}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,13 +1,14 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { abortRun, openEvents, RunPayload, startRun, openPath, listRuns, downloadManifest, fetchManifest, fileUrl } from './api'
 import './theme.css'
+import { parseResolutions } from './utils'
 
-const section: React.CSSProperties = { marginBlock: '16px', padding: '16px', border: '1px solid #e6e6e6', borderRadius: 12, background: 'var(--card-bg)' }
-const label: React.CSSProperties = { display: 'block', fontSize: 12, color: '#666', marginBottom: 6 }
-const input: React.CSSProperties = { width: '100%', padding: '10px 12px', borderRadius: 8, border: '1px solid #ddd', outline: 'none' }
-const row: React.CSSProperties = { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }
-const button: React.CSSProperties = { padding: '10px 14px', borderRadius: 8, border: '1px solid #0b6', background: '#0b6', color: '#fff', cursor: 'pointer' }
-const buttonGhost: React.CSSProperties = { ...button, background: '#fff', color: '#0b6' }
+const section: React.CSSProperties = { marginBlock: 20, padding: 20, border: '1px solid var(--border)', borderRadius: 16, background: 'var(--card-bg)' }
+const label: React.CSSProperties = { display: 'block', fontSize: 12, color: 'var(--muted)', marginBottom: 8 }
+const input: React.CSSProperties = { width: '100%', padding: '12px 14px', borderRadius: 10, border: '1px solid var(--border)', background: 'var(--card-bg)', color: 'var(--fg)', outline: 'none' }
+const row: React.CSSProperties = { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }
+const button: React.CSSProperties = { padding: '12px 16px', borderRadius: 10, border: '1px solid transparent', background: 'var(--accent-grad)', color: '#fff', cursor: 'pointer' }
+const buttonGhost: React.CSSProperties = { padding: '12px 16px', borderRadius: 10, border: '1px solid var(--accent)', background: 'transparent', color: 'var(--fg)', cursor: 'pointer' }
 
 export default function App() {
   const [url, setUrl] = useState('https://example.com')
@@ -48,7 +49,6 @@ export default function App() {
   const [runId, setRunId] = useState<string | null>(null)
   const [runs, setRuns] = useState<any[]>([])
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
-  const [logIndex, setLogIndex] = useState(0)
   const [logs, setLogs] = useState<string[]>([])
   const [status, setStatus] = useState<'idle'|'running'|'completed'|'failed'|'aborted'>('idle')
   const [exitCode, setExitCode] = useState<number | null>(null)
@@ -58,12 +58,15 @@ export default function App() {
   const [resProgress, setResProgress] = useState({current: 0, total: 0})
   const [headful, setHeadful] = useState(false)
   const [autoScroll, setAutoScroll] = useState(true)
+  const [wrapLogs, setWrapLogs] = useState<boolean>(() => {
+    try { return JSON.parse(localStorage.getItem('cns:wrapLogs') || 'true') } catch { return true }
+  })
   const logsRef = useRef<HTMLPreElement | null>(null)
   const logsEndRef = useRef<HTMLDivElement | null>(null)
 
   const payload: RunPayload = useMemo(() => ({
     url,
-    resolutions: resolutions.split(',').map(s => s.trim()).filter(Boolean),
+    resolutions: parseResolutions(resolutions),
     desktop,
     mobile,
     browser,
@@ -92,23 +95,22 @@ export default function App() {
         setStatus(data.status)
         setExitCode(data.exitCode)
         setManifestPath(data.manifestPath)
-      } catch {}
+      } catch { /* ignore parse errors */ }
     })
     es.addEventListener('logs', (ev: MessageEvent) => {
       try {
         const data = JSON.parse((ev as any).data)
         if (data.lines?.length) {
           setLogs(prev => [...prev, ...data.lines])
-          setLogIndex(data.next)
         }
-      } catch {}
+      } catch { /* ignore parse errors */ }
     })
     es.addEventListener('metrics', (ev: MessageEvent) => {
       try {
         const m = JSON.parse((ev as any).data)
         setPageProgress({current: m.pageCurrent || 0, total: m.pageTotal || 0})
         setResProgress({current: m.resCurrent || 0, total: m.resTotal || 0})
-      } catch {}
+      } catch { /* ignore parse errors */ }
     })
     return () => es.close()
   }, [runId])
@@ -121,19 +123,17 @@ export default function App() {
 
   // Load runs periodically
   useEffect(() => {
-    let t: any
     const load = async () => {
-      try { setRuns(await listRuns()) } catch {}
+      try { setRuns(await listRuns()) } catch { /* ignore */ }
     }
     load()
-    t = setInterval(load, 1500)
+    const t = setInterval(load, 1500)
     return () => clearInterval(t)
   }, [])
 
   async function onRun(e: React.FormEvent) {
     e.preventDefault()
     setLogs([])
-    setLogIndex(0)
     setExitCode(null)
     setManifestPath(null)
     setStatus('running')
@@ -153,10 +153,14 @@ export default function App() {
     localStorage.setItem('cns:theme', theme)
   }, [theme])
 
+  useEffect(() => {
+    try { localStorage.setItem('cns:wrapLogs', JSON.stringify(wrapLogs)) } catch { /* ignore */ }
+  }, [wrapLogs])
+
   return (
     <div style={{ fontFamily: 'ui-sans-serif, system-ui, -apple-system', background: 'var(--bg)', color: 'var(--fg)', minHeight: '100vh' }}>
-      <div style={{ maxWidth: 1100, margin: '0 auto', padding: '24px' }}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <div style={{ maxWidth: 1200, margin: '0 auto', padding: 32 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
           <div>
             <h1 style={{ marginBottom: 4 }}>Crawl‑n‑Snap</h1>
             <p style={{ color: 'var(--muted)', marginTop: 0 }}>Interactive UI for the CLI. Fill in options and run.</p>
@@ -249,7 +253,8 @@ export default function App() {
               }}>Save</button>
               <button type="button" style={buttonGhost} onClick={()=>{
                 if (!profileName) return;
-                const {[profileName]:_, ...rest} = profiles;
+                const rest = { ...profiles } as Record<string, any>;
+                delete (rest as any)[profileName];
                 setProfiles(rest);
                 setProfileName('');
                 localStorage.setItem('cns:profiles', JSON.stringify(rest));
@@ -321,7 +326,7 @@ export default function App() {
 
         <div className="card" style={{ marginTop: 16 }}>
           <div className="two-col">
-            <div style={{ borderRight: '1px solid #e6e6e6', paddingRight: 12 }}>
+            <div style={{ borderRight: '1px solid var(--border)', paddingRight: 12 }}>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                 <h3 style={{ margin: 0 }}>Run History</h3>
                 <button type="button" style={buttonGhost} onClick={async ()=> setRuns(await listRuns())}>Refresh</button>
@@ -337,7 +342,7 @@ export default function App() {
                 {!runs.length && <div style={{ color: 'var(--muted)' }}>No runs yet.</div>}
               </div>
             </div>
-            <div>
+            <div style={{ minWidth: 0 }}>
               {/* Progress + status + logs */}
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
             <div>
@@ -346,7 +351,7 @@ export default function App() {
                 <span>{pageProgress.current}/{pageProgress.total || '?'}</span>
               </div>
               <div style={{ height: 8, borderRadius: 999, background: 'var(--bar-bg)' }}>
-                <div style={{ height: '100%', borderRadius: 999, width: `${pageProgress.total? Math.min(100, Math.round(pageProgress.current / pageProgress.total * 100)) : 0}%`, background: 'var(--accent)' }} />
+                <div style={{ height: '100%', borderRadius: 999, width: `${pageProgress.total? Math.min(100, Math.round(pageProgress.current / pageProgress.total * 100)) : 0}%`, backgroundImage: 'var(--accent-grad)' }} />
               </div>
             </div>
             <div>
@@ -355,7 +360,7 @@ export default function App() {
                 <span>{resProgress.current}/{resProgress.total || '?'}</span>
               </div>
               <div style={{ height: 8, borderRadius: 999, background: 'var(--bar-bg)' }}>
-                <div style={{ height: '100%', borderRadius: 999, width: `${resProgress.total? Math.min(100, Math.round(resProgress.current / resProgress.total * 100)) : 0}%`, background: 'var(--accent)' }} />
+                <div style={{ height: '100%', borderRadius: 999, width: `${resProgress.total? Math.min(100, Math.round(resProgress.current / resProgress.total * 100)) : 0}%`, backgroundImage: 'var(--accent-grad)' }} />
               </div>
             </div>
           </div>
@@ -367,9 +372,10 @@ export default function App() {
               <a href="#" onClick={async (e)=>{ e.preventDefault(); if(manifestPath) await openPath(manifestPath, 'dir') }} style={{ color: 'var(--accent)' }}>Open folder</a>
               <a href="#" onClick={async (e)=>{ e.preventDefault(); if(selectedRunId) await downloadManifest(selectedRunId) }} style={{ color: 'var(--accent)' }}>Download manifest</a>
             </>}
-            <label style={{ marginLeft: 'auto' }}><input type="checkbox" checked={autoScroll} onChange={e=>setAutoScroll(e.target.checked)} /> Auto-scroll logs</label>
+            <label style={{ marginLeft: 'auto' }}><input type="checkbox" checked={autoScroll} onChange={e=>setAutoScroll(e.target.checked)} /> Auto-scroll</label>
+            <label><input type="checkbox" checked={wrapLogs} onChange={e=>setWrapLogs(e.target.checked)} /> Wrap lines</label>
           </div>
-          <pre ref={logsRef} style={{ marginTop: 12, background: 'var(--logs-bg)', color: 'var(--logs-fg)', padding: 12, borderRadius: 8, maxHeight: 400, overflow: 'auto' }}>
+          <pre ref={logsRef} className="terminal" style={{ marginTop: 12, maxHeight: 400, whiteSpace: wrapLogs ? 'pre-wrap' as const : 'pre' as const, wordBreak: wrapLogs ? 'break-word' : 'normal' }}>
 {logs.join('\n')}
           </pre>
           <div ref={logsEndRef} />

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,0 +1,461 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { abortRun, openEvents, RunPayload, startRun, openPath, listRuns, downloadManifest, fetchManifest, fileUrl } from './api'
+import './theme.css'
+
+const section: React.CSSProperties = { marginBlock: '16px', padding: '16px', border: '1px solid #e6e6e6', borderRadius: 12, background: 'var(--card-bg)' }
+const label: React.CSSProperties = { display: 'block', fontSize: 12, color: '#666', marginBottom: 6 }
+const input: React.CSSProperties = { width: '100%', padding: '10px 12px', borderRadius: 8, border: '1px solid #ddd', outline: 'none' }
+const row: React.CSSProperties = { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }
+const button: React.CSSProperties = { padding: '10px 14px', borderRadius: 8, border: '1px solid #0b6', background: '#0b6', color: '#fff', cursor: 'pointer' }
+const buttonGhost: React.CSSProperties = { ...button, background: '#fff', color: '#0b6' }
+
+export default function App() {
+  const [url, setUrl] = useState('https://example.com')
+  const [resolutions, setResolutions] = useState('1920x1080, 390x844')
+  const [browser, setBrowser] = useState<'chromium'|'firefox'|'webkit'>('chromium')
+  const [output, setOutput] = useState('./generated-screenshots')
+  const [crawl, setCrawl] = useState(false)
+  const [maxPages, setMaxPages] = useState(50)
+  const [timeout, setTimeoutMs] = useState(5000)
+  const [concurrency, setConcurrency] = useState(3)
+  const [retries, setRetries] = useState(2)
+  const [includePatterns, setInclude] = useState('')
+  const [excludePatterns, setExclude] = useState('')
+  const [waitUntil, setWaitUntil] = useState<'load'|'domcontentloaded'|'networkidle'|'commit'>('networkidle')
+  const [delay, setDelay] = useState(0)
+  const [fullPage, setFullPage] = useState(true)
+  const [continueOnError, setContinue] = useState(true)
+  const [failFast, setFailFast] = useState(false)
+  const [desktop, setDesktop] = useState(true)
+  const [mobile, setMobile] = useState(false)
+  const [profiles, setProfiles] = useState<Record<string, any>>(() => {
+    try { return JSON.parse(localStorage.getItem('cns:profiles') || '{}') } catch { return {} }
+  })
+  const [profileName, setProfileName] = useState<string>('')
+  const DEVICE_PRESETS: Array<{name: string, res: string}> = [
+    { name: 'Desktop 1920x1080', res: '1920x1080' },
+    { name: 'Desktop 1366x768', res: '1366x768' },
+    { name: 'MacBook Pro 14" (1512x982)', res: '1512x982' },
+    { name: 'iPhone 12/13 (390x844)', res: '390x844' },
+    { name: 'iPhone SE (375x667)', res: '375x667' },
+    { name: 'Pixel 7 (412x915)', res: '412x915' },
+    { name: 'Galaxy S22 (360x780)', res: '360x780' },
+    { name: 'iPad (768x1024)', res: '768x1024' },
+    { name: 'iPad Pro (1024x1366)', res: '1024x1366' },
+  ]
+  const [devicePreset, setDevicePreset] = useState<string>('')
+
+  const [runId, setRunId] = useState<string | null>(null)
+  const [runs, setRuns] = useState<any[]>([])
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
+  const [logIndex, setLogIndex] = useState(0)
+  const [logs, setLogs] = useState<string[]>([])
+  const [status, setStatus] = useState<'idle'|'running'|'completed'|'failed'|'aborted'>('idle')
+  const [exitCode, setExitCode] = useState<number | null>(null)
+  const [manifestPath, setManifestPath] = useState<string | null>(null)
+  const [theme, setTheme] = useState<'light'|'dark'>(() => (localStorage.getItem('cns:theme') as any) || 'light')
+  const [pageProgress, setPageProgress] = useState({current: 0, total: 0})
+  const [resProgress, setResProgress] = useState({current: 0, total: 0})
+  const [headful, setHeadful] = useState(false)
+  const [autoScroll, setAutoScroll] = useState(true)
+  const logsRef = useRef<HTMLPreElement | null>(null)
+  const logsEndRef = useRef<HTMLDivElement | null>(null)
+
+  const payload: RunPayload = useMemo(() => ({
+    url,
+    resolutions: resolutions.split(',').map(s => s.trim()).filter(Boolean),
+    desktop,
+    mobile,
+    browser,
+    output,
+    crawl,
+    maxPages,
+    timeout,
+    concurrency,
+    retries,
+    includePatterns: includePatterns ? includePatterns.split(',').map(s => s.trim()).filter(Boolean) : [],
+    excludePatterns: excludePatterns ? excludePatterns.split(',').map(s => s.trim()).filter(Boolean) : [],
+    waitUntil,
+    delay,
+    fullPage,
+    continueOnError,
+    failFast,
+    headless: !headful,
+  }), [url, resolutions, desktop, mobile, browser, output, crawl, maxPages, timeout, concurrency, retries, includePatterns, excludePatterns, waitUntil, delay, fullPage, continueOnError, failFast, headful])
+
+  useEffect(() => {
+    if (!runId) return
+    const es = openEvents(runId)
+    es.addEventListener('status', (ev: MessageEvent) => {
+      try {
+        const data = JSON.parse((ev as any).data)
+        setStatus(data.status)
+        setExitCode(data.exitCode)
+        setManifestPath(data.manifestPath)
+      } catch {}
+    })
+    es.addEventListener('logs', (ev: MessageEvent) => {
+      try {
+        const data = JSON.parse((ev as any).data)
+        if (data.lines?.length) {
+          setLogs(prev => [...prev, ...data.lines])
+          setLogIndex(data.next)
+        }
+      } catch {}
+    })
+    es.addEventListener('metrics', (ev: MessageEvent) => {
+      try {
+        const m = JSON.parse((ev as any).data)
+        setPageProgress({current: m.pageCurrent || 0, total: m.pageTotal || 0})
+        setResProgress({current: m.resCurrent || 0, total: m.resTotal || 0})
+      } catch {}
+    })
+    return () => es.close()
+  }, [runId])
+
+  useEffect(() => {
+    if (status === 'running' && autoScroll) {
+      logsEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
+    }
+  }, [logs, status, autoScroll])
+
+  // Load runs periodically
+  useEffect(() => {
+    let t: any
+    const load = async () => {
+      try { setRuns(await listRuns()) } catch {}
+    }
+    load()
+    t = setInterval(load, 1500)
+    return () => clearInterval(t)
+  }, [])
+
+  async function onRun(e: React.FormEvent) {
+    e.preventDefault()
+    setLogs([])
+    setLogIndex(0)
+    setExitCode(null)
+    setManifestPath(null)
+    setStatus('running')
+    const { runId } = await startRun(payload)
+    setRunId(runId)
+    setSelectedRunId(runId)
+  }
+
+  async function onAbort() {
+    if (!runId) return
+    await abortRun(runId)
+    setStatus('aborted')
+  }
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme)
+    localStorage.setItem('cns:theme', theme)
+  }, [theme])
+
+  return (
+    <div style={{ fontFamily: 'ui-sans-serif, system-ui, -apple-system', background: 'var(--bg)', color: 'var(--fg)', minHeight: '100vh' }}>
+      <div style={{ maxWidth: 1100, margin: '0 auto', padding: '24px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div>
+            <h1 style={{ marginBottom: 4 }}>Crawl‑n‑Snap</h1>
+            <p style={{ color: 'var(--muted)', marginTop: 0 }}>Interactive UI for the CLI. Fill in options and run.</p>
+          </div>
+          <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+            <label><input type="checkbox" checked={headful} onChange={e=>setHeadful(e.target.checked)} /> Headful (show browser)</label>
+            <button type="button" style={buttonGhost} onClick={()=>setTheme(prev => prev==='light'?'dark':'light')}>
+              {theme==='light' ? 'Dark mode' : 'Light mode'}
+            </button>
+          </div>
+        </div>
+
+        <form onSubmit={onRun}>
+          <div style={section}>
+            <label style={label}>URL</label>
+            <input style={input} value={url} onChange={e=>setUrl(e.target.value)} placeholder="https://example.com" />
+          </div>
+
+          <div style={{ ...section, display: 'grid', gap: 12 }}>
+            <div>
+              <label style={label}>Resolutions (comma separated)</label>
+              <input style={input} value={resolutions} onChange={e=>setResolutions(e.target.value)} />
+            </div>
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+              <select style={{ ...input, height: 40, maxWidth: 280 }} value={devicePreset} onChange={e=>setDevicePreset(e.target.value)}>
+                <option value="">— Device catalog —</option>
+                {DEVICE_PRESETS.map(d => <option key={d.res} value={d.res}>{d.name}</option>)}
+              </select>
+              <button type="button" style={buttonGhost} disabled={!devicePreset} onClick={()=>{
+                if (!devicePreset) return; setResolutions(devicePreset)
+              }}>Apply device</button>
+              <button type="button" style={buttonGhost} disabled={!devicePreset} onClick={()=>{
+                if (!devicePreset) return;
+                const list = new Set(resolutions.split(',').map(s=>s.trim()).filter(Boolean));
+                list.add(devicePreset);
+                setResolutions(Array.from(list).join(', '))
+              }}>Add device</button>
+            </div>
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+              <button type="button" style={buttonGhost} onClick={()=>setResolutions('1920x1080, 1366x768, 1440x900')}>Apply Desktop</button>
+              <button type="button" style={buttonGhost} onClick={()=>setResolutions('390x844, 375x667, 360x640')}>Apply Mobile</button>
+              <button type="button" style={buttonGhost} onClick={()=>setResolutions('1920x1080, 1366x768, 1440x900, 390x844, 375x667, 360x640')}>Apply All</button>
+            </div>
+            <div style={row}>
+              <label><input type="checkbox" checked={desktop} onChange={e=>setDesktop(e.target.checked)} /> Desktop preset</label>
+              <label><input type="checkbox" checked={mobile} onChange={e=>setMobile(e.target.checked)} /> Mobile preset</label>
+            </div>
+            <div style={row}>
+              <div>
+                <label style={label}>Browser</label>
+                <select style={{ ...input, height: 40 }} value={browser} onChange={e=>setBrowser(e.target.value as any)}>
+                  <option value="chromium">chromium</option>
+                  <option value="firefox">firefox</option>
+                  <option value="webkit">webkit</option>
+                </select>
+              </div>
+              <div>
+                <label style={label}>Output directory</label>
+                <input style={input} value={output} onChange={e=>setOutput(e.target.value)} />
+              </div>
+            </div>
+          </div>
+
+          <div style={{ ...section, display: 'grid', gap: 12 }}>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <span style={{ color: 'var(--muted)' }}>Profiles</span>
+              <select style={{ ...input, height: 40, maxWidth: 280 }} value={profileName} onChange={(e)=>{
+                const name = e.target.value; setProfileName(name);
+                const p = profiles[name]; if (!p) return;
+                setUrl(p.url || url);
+                setResolutions((p.resolutions || []).join(', '));
+                setDesktop(!!p.desktop); setMobile(!!p.mobile);
+                setBrowser(p.browser || 'chromium'); setOutput(p.output || './generated-screenshots');
+                setCrawl(!!p.crawl); setMaxPages(p.maxPages ?? 50);
+                setTimeoutMs(p.timeout ?? 5000); setConcurrency(p.concurrency ?? 3); setRetries(p.retries ?? 2);
+                setInclude((p.includePatterns || []).join(', ')); setExclude((p.excludePatterns || []).join(', '));
+                setWaitUntil(p.waitUntil || 'networkidle'); setDelay(p.delay ?? 0); setFullPage(p.fullPage ?? true);
+                setContinue(p.continueOnError ?? true); setFailFast(!!p.failFast); setHeadful(p.headless === false);
+              }}>
+                <option value="">— Select profile —</option>
+                {Object.keys(profiles).map(name => <option key={name} value={name}>{name}</option>)}
+              </select>
+              <button type="button" style={buttonGhost} onClick={()=>{
+                const name = prompt('Profile name:');
+                if (!name) return;
+                const next = { ...profiles, [name]: payload };
+                setProfiles(next);
+                setProfileName(name);
+                localStorage.setItem('cns:profiles', JSON.stringify(next));
+              }}>Save</button>
+              <button type="button" style={buttonGhost} onClick={()=>{
+                if (!profileName) return;
+                const {[profileName]:_, ...rest} = profiles;
+                setProfiles(rest);
+                setProfileName('');
+                localStorage.setItem('cns:profiles', JSON.stringify(rest));
+              }} disabled={!profileName}>Delete</button>
+            </div>
+          </div>
+
+          <div style={{ ...section, display: 'grid', gap: 12 }}>
+            <div style={row}>
+              <label><input type="checkbox" checked={crawl} onChange={e=>setCrawl(e.target.checked)} /> Crawl site</label>
+              <div>
+                <label style={label}>Max pages</label>
+                <input style={input} type="number" value={maxPages} onChange={e=>setMaxPages(parseInt(e.target.value))} />
+              </div>
+            </div>
+            <div style={row}>
+              <div>
+                <label style={label}>Timeout (ms)</label>
+                <input style={input} type="number" value={timeout} onChange={e=>setTimeoutMs(parseInt(e.target.value))} />
+              </div>
+              <div>
+                <label style={label}>Concurrency</label>
+                <input style={input} type="number" value={concurrency} onChange={e=>setConcurrency(parseInt(e.target.value))} />
+              </div>
+            </div>
+            <div style={row}>
+              <div>
+                <label style={label}>Retries</label>
+                <input style={input} type="number" value={retries} onChange={e=>setRetries(parseInt(e.target.value))} />
+              </div>
+              <div>
+                <label style={label}>waitUntil</label>
+                <select style={{ ...input, height: 40 }} value={waitUntil} onChange={e=>setWaitUntil(e.target.value as any)}>
+                  <option value="load">load</option>
+                  <option value="domcontentloaded">domcontentloaded</option>
+                  <option value="networkidle">networkidle</option>
+                  <option value="commit">commit</option>
+                </select>
+              </div>
+            </div>
+            <div style={row}>
+              <div>
+                <label style={label}>Delay (ms)</label>
+                <input style={input} type="number" value={delay} onChange={e=>setDelay(parseInt(e.target.value))} />
+              </div>
+              <label><input type="checkbox" checked={fullPage} onChange={e=>setFullPage(e.target.checked)} /> Full page</label>
+            </div>
+            <div style={row}>
+              <div>
+                <label style={label}>Include patterns (comma)</label>
+                <input style={input} value={includePatterns} onChange={e=>setInclude(e.target.value)} />
+              </div>
+              <div>
+                <label style={label}>Exclude patterns (comma)</label>
+                <input style={input} value={excludePatterns} onChange={e=>setExclude(e.target.value)} />
+              </div>
+            </div>
+            <div style={row}>
+              <label><input type="checkbox" checked={continueOnError} onChange={e=>setContinue(e.target.checked)} /> Continue on error</label>
+              <label><input type="checkbox" checked={failFast} onChange={e=>setFailFast(e.target.checked)} /> Fail fast</label>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', gap: 12 }}>
+            <button type="submit" style={button} disabled={status==='running'}>Run</button>
+            <button type="button" style={buttonGhost} onClick={onAbort} disabled={!runId || status!=='running'}>Abort</button>
+          </div>
+        </form>
+
+        <div className="card" style={{ marginTop: 16 }}>
+          <div className="two-col">
+            <div style={{ borderRight: '1px solid #e6e6e6', paddingRight: 12 }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                <h3 style={{ margin: 0 }}>Run History</h3>
+                <button type="button" style={buttonGhost} onClick={async ()=> setRuns(await listRuns())}>Refresh</button>
+              </div>
+              <div style={{ marginTop: 12, display: 'grid', gap: 8, maxHeight: 300, overflow: 'auto' }}>
+                {runs.map(r => (
+                  <div key={r.id} onClick={()=>setSelectedRunId(r.id)} style={{ padding: 8, borderRadius: 8, cursor: 'pointer', background: selectedRunId===r.id ? 'var(--bar-bg)' : 'transparent' }}>
+                    <div style={{ fontWeight: 600, fontSize: 13 }}>{r.status.toUpperCase()} {r.exitCode!==null?`(${r.exitCode})`:''}</div>
+                    <div style={{ fontSize: 12, color: 'var(--muted)' }}>{new Date(r.startedAt).toLocaleString()}</div>
+                    <div style={{ fontSize: 12, color: 'var(--muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.url}</div>
+                  </div>
+                ))}
+                {!runs.length && <div style={{ color: 'var(--muted)' }}>No runs yet.</div>}
+              </div>
+            </div>
+            <div>
+              {/* Progress + status + logs */}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+            <div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, color: 'var(--muted)' }}>
+                <span>Pages</span>
+                <span>{pageProgress.current}/{pageProgress.total || '?'}</span>
+              </div>
+              <div style={{ height: 8, borderRadius: 999, background: 'var(--bar-bg)' }}>
+                <div style={{ height: '100%', borderRadius: 999, width: `${pageProgress.total? Math.min(100, Math.round(pageProgress.current / pageProgress.total * 100)) : 0}%`, background: 'var(--accent)' }} />
+              </div>
+            </div>
+            <div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, color: 'var(--muted)' }}>
+                <span>Resolutions (current page)</span>
+                <span>{resProgress.current}/{resProgress.total || '?'}</span>
+              </div>
+              <div style={{ height: 8, borderRadius: 999, background: 'var(--bar-bg)' }}>
+                <div style={{ height: '100%', borderRadius: 999, width: `${resProgress.total? Math.min(100, Math.round(resProgress.current / resProgress.total * 100)) : 0}%`, background: 'var(--accent)' }} />
+              </div>
+            </div>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+            <span>Status: <strong>{status}</strong>{exitCode!==null ? ` (exit ${exitCode})` : ''}</span>
+            {manifestPath && <>
+              <a href="#" onClick={(e)=>{ e.preventDefault(); navigator.clipboard.writeText(manifestPath!) }} style={{ color: 'var(--accent)' }}>Copy manifest path</a>
+              <a href="#" onClick={async (e)=>{ e.preventDefault(); if(manifestPath) await openPath(manifestPath, 'reveal') }} style={{ color: 'var(--accent)' }}>Reveal</a>
+              <a href="#" onClick={async (e)=>{ e.preventDefault(); if(manifestPath) await openPath(manifestPath, 'dir') }} style={{ color: 'var(--accent)' }}>Open folder</a>
+              <a href="#" onClick={async (e)=>{ e.preventDefault(); if(selectedRunId) await downloadManifest(selectedRunId) }} style={{ color: 'var(--accent)' }}>Download manifest</a>
+            </>}
+            <label style={{ marginLeft: 'auto' }}><input type="checkbox" checked={autoScroll} onChange={e=>setAutoScroll(e.target.checked)} /> Auto-scroll logs</label>
+          </div>
+          <pre ref={logsRef} style={{ marginTop: 12, background: 'var(--logs-bg)', color: 'var(--logs-fg)', padding: 12, borderRadius: 8, maxHeight: 400, overflow: 'auto' }}>
+{logs.join('\n')}
+          </pre>
+          <div ref={logsEndRef} />
+            </div>
+          </div>
+        </div>
+
+        {/* Structured Results */}
+        <RunResults selectedRunId={selectedRunId} runs={runs} />
+      </div>
+    </div>
+  )
+}
+
+function RunResults({ selectedRunId, runs }: { selectedRunId: string | null, runs: any[] }) {
+  const [manifest, setManifest] = useState<any | null>(null)
+  const selected = useMemo(() => runs.find(r => r.id === selectedRunId) || null, [runs, selectedRunId])
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      if (!selectedRunId) { setManifest(null); return }
+      // Only fetch when manifest path is available
+      if (!selected?.manifestPath) { setManifest(null); return }
+      try {
+        const data = await fetchManifest(selectedRunId)
+        if (!cancelled) setManifest(data)
+      } catch {
+        if (!cancelled) setManifest(null)
+      }
+    }
+    load()
+    return () => { cancelled = true }
+  }, [selectedRunId, selected?.manifestPath])
+
+  if (!selectedRunId) return null
+
+  return (
+    <div style={{ ...section }}>
+      <h3 style={{ marginTop: 0 }}>Results</h3>
+      {!selected?.manifestPath ? (
+        <div style={{ color: 'var(--muted)' }}>Waiting for manifest...</div>
+      ) : !manifest ? (
+        <div style={{ color: 'var(--muted)' }}>Loading manifest…</div>
+      ) : (
+        <div style={{ display: 'grid', gap: 12 }}>
+          <div>
+            <strong>Target:</strong> {manifest.target}
+          </div>
+          <div style={{ display: 'flex', gap: 24, color: 'var(--muted)' }}>
+            <div>Pages: {manifest.summary?.pagesProcessed ?? '?'}</div>
+            <div>Errors: {manifest.summary?.totalErrors ?? 0}</div>
+            <div>Any failures: {String(manifest.summary?.anyFailures ?? false)}</div>
+          </div>
+          <div>
+            <strong>Options:</strong>
+            <div style={{ fontSize: 12, color: 'var(--muted)' }}>{JSON.stringify(manifest.options)}</div>
+          </div>
+          <div>
+            <strong>Pages:</strong>
+            <div style={{ display: 'grid', gap: 8, marginTop: 8 }}>
+              {(manifest.pages || []).slice(0, 50).map((p: any, i: number) => (
+                <div key={i} style={{ padding: 8, border: '1px solid #e6e6e6', borderRadius: 8 }}>
+                  <div style={{ fontWeight: 600 }}>{p.url}</div>
+                  <div className="preview-grid" style={{ marginTop: 6 }}>
+                    {p.results.map((r: any, j: number) => (
+                      <div key={j} className="preview" title={r.outputPath || r.error}>
+                        {r.outputPath && r.success ? (
+                          <>
+                            <span className="chip">{r.resolution}</span>
+                            <img src={fileUrl(r.outputPath)} alt={r.resolution} />
+                          </>
+                        ) : (
+                          <div style={{ padding: 8, fontSize: 12, color: 'var(--muted)' }}>
+                            <strong>{r.resolution}</strong> ✗ {r.error || 'Failed'}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,0 +1,106 @@
+export type RunPayload = {
+  url: string;
+  resolutions: string[];
+  desktop?: boolean;
+  mobile?: boolean;
+  output?: string;
+  browser?: 'chromium' | 'firefox' | 'webkit';
+  crawl?: boolean;
+  maxPages?: number;
+  timeout?: number;
+  concurrency?: number;
+  retries?: number;
+  includePatterns?: string[];
+  excludePatterns?: string[];
+  continueOnError?: boolean;
+  failFast?: boolean;
+  waitUntil?: 'load' | 'domcontentloaded' | 'networkidle' | 'commit';
+  delay?: number;
+  fullPage?: boolean;
+  headless?: boolean;
+};
+
+export async function startRun(body: RunPayload): Promise<{runId: string}> {
+  const res = await fetch('/api/run', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error('Failed to start run');
+  return res.json();
+}
+
+export type LogsResponse = {
+  status: 'running' | 'completed' | 'failed' | 'aborted';
+  logs: string[];
+  next: number;
+  exitCode: number | null;
+  manifestPath: string | null;
+  startedAt: number;
+  finishedAt: number | null;
+};
+
+export async function fetchLogs(runId: string, since = 0): Promise<LogsResponse> {
+  const res = await fetch(`/api/logs/${runId}?since=${since}`);
+  if (!res.ok) throw new Error('Failed to fetch logs');
+  return res.json();
+}
+
+export async function abortRun(runId: string): Promise<void> {
+  const res = await fetch(`/api/run/${runId}`, {method: 'DELETE'});
+  if (!res.ok) throw new Error('Failed to abort run');
+}
+
+export function openEvents(runId: string): EventSource {
+  return new EventSource(`/api/events/${runId}`);
+}
+
+export async function openPath(
+  path: string,
+  mode: 'file' | 'dir' | 'reveal' = 'file'
+): Promise<void> {
+  const res = await fetch('/api/open', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({path, mode}),
+  });
+  if (!res.ok) throw new Error('Failed to open path');
+}
+
+export type RunSummary = {
+  id: string;
+  url: string;
+  status: 'running' | 'completed' | 'failed' | 'aborted';
+  startedAt: number;
+  finishedAt: number | null;
+  exitCode: number | null;
+  manifestPath: string | null;
+};
+
+export async function listRuns(): Promise<RunSummary[]> {
+  const res = await fetch('/api/runs');
+  if (!res.ok) throw new Error('Failed to list runs');
+  return res.json();
+}
+
+export async function fetchManifest(runId: string): Promise<any> {
+  const res = await fetch(`/api/run/${runId}/manifest`);
+  if (!res.ok) throw new Error('Failed to fetch manifest');
+  return res.json();
+}
+
+export async function downloadManifest(runId: string): Promise<void> {
+  const res = await fetch(`/api/run/${runId}/manifest?download=1`);
+  if (!res.ok) throw new Error('Failed to download manifest');
+  const blob = await res.blob();
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = `run-${runId}.json`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}
+
+export function fileUrl(p: string): string {
+  return `/api/file?path=${encodeURIComponent(p)}`;
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+
+createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)
+

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -1,40 +1,60 @@
 :root {
-  --bg: #f6f7f9;
-  --fg: #0a0a0a;
-  --muted: #666;
-  --accent: #0b6;
-  --bar-bg: #e6e6e6;
-  --card-bg: #fff;
-  --logs-bg: #0a0a0a;
-  --logs-fg: #e6e6e6;
-  --border: #e6e6e6;
-  --shadow: 0 4px 14px rgba(0,0,0,0.08);
+  /* Base */
+  --bg: #f5f7fb;
+  --fg: #0b1220;
+  --muted: #637084;
+  --border: #e2e8f0;
+
+  /* Vibrant accent */
+  --accent: #7c3aed; /* primary stop */
+  --accent-2: #06b6d4; /* secondary stop */
+  --accent-grad: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+
+  /* Surfaces */
+  --bar-bg: #e9eef7;
+  --card-bg: #ffffff;
+  --logs-bg: #0b1220;
+  --logs-fg: #e6eef8;
+
+  /* Elevation */
+  --shadow: 0 10px 30px rgba(20, 30, 60, 0.12);
 }
 
 :root[data-theme='dark'] {
-  --bg: #0b0e14;
-  --fg: #e6e6e6;
-  --muted: #a0a0a0;
-  --accent: #34d399;
-  --bar-bg: #2a2f3a;
-  --card-bg: #111827;
-  --logs-bg: #0a0a0a;
-  --logs-fg: #e6e6e6;
-  --border: #1f2937;
-  --shadow: 0 6px 20px rgba(0,0,0,0.25);
+  --bg: #0b0f19;
+  --fg: #e6eef8;
+  --muted: #9aa8bd;
+  --border: #1f2b3b;
+
+  /* keep accent vibrant in dark */
+  --accent: #8b5cf6;
+  --accent-2: #06b6d4;
+  --accent-grad: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+
+  --bar-bg: #172033;
+  --card-bg: #0f1726;
+  --logs-bg: #0b1220;
+  --logs-fg: #e6eef8;
+  --shadow: 0 14px 40px rgba(0,0,0,0.45);
 }
 
+/* Base reset */
+html, body, #root { height: 100%; }
+body { margin: 0; background: var(--bg); color: var(--fg); -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+* { box-sizing: border-box; }
+
 /* Layout */
-.container { max-width: 1200px; margin: 0 auto; padding: 24px; }
-.header { display:flex; align-items:center; justify-content:space-between; margin-bottom: 8px; }
+.container { max-width: 1200px; margin: 0 auto; padding: 32px; }
+.header { display:flex; align-items:center; justify-content:space-between; margin-bottom: 12px; }
 .subtitle { color: var(--muted); margin: 0; }
 
 /* Cards & Inputs */
-.card { margin-block: 16px; padding: 16px; border: 1px solid var(--border); border-radius: 12px; background: var(--card-bg); box-shadow: var(--shadow); }
-.label { display:block; font-size:12px; color: var(--muted); margin-bottom: 6px; }
-.input { width:100%; padding:10px 12px; border-radius:8px; border:1px solid var(--border); background: var(--card-bg); color: var(--fg); outline:none; }
-.row { display:grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-.grid { display:grid; gap:12px; }
+.card { margin-block: 20px; padding: 20px; border: 1px solid var(--border); border-radius: 16px; background: var(--card-bg); box-shadow: var(--shadow); }
+.label { display:block; font-size:12px; color: var(--muted); margin-bottom: 8px; letter-spacing: .02em; }
+.input { width:100%; padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: var(--card-bg); color: var(--fg); outline:none; box-shadow: 0 1px 0 rgba(20,30,60,0.02) inset; }
+.input:focus { border-color: transparent; outline: 3px solid color-mix(in srgb, var(--accent) 30%, transparent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 30%, transparent); }
+.row { display:grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.grid { display:grid; gap:16px; }
 
 /* Responsive layout */
 .two-col { display:grid; grid-template-columns: 280px 1fr; gap: 16px; }
@@ -46,22 +66,38 @@
 .sticky-actions { position: sticky; bottom: 0; background: var(--bg); padding-top: 8px; margin-top: 8px; }
 
 /* Subtle transitions */
-.btn, .btn-ghost { transition: transform .05s ease, box-shadow .2s ease, background-color .2s ease, color .2s ease; }
+.btn, .btn-ghost { transition: transform .05s ease, box-shadow .2s ease, background-image .2s ease, background-color .2s ease, color .2s ease, border-color .2s ease; }
 .btn:hover, .btn-ghost:hover { box-shadow: var(--shadow); }
 .btn:active, .btn-ghost:active { transform: translateY(1px); }
 
 /* Buttons */
-.btn { padding: 10px 14px; border-radius: 8px; border: 1px solid var(--accent); background: var(--accent); color: #fff; cursor: pointer; }
+.btn { padding: 12px 16px; border-radius: 10px; border: 1px solid transparent; background-image: var(--accent-grad); color: #fff; cursor: pointer; }
 .btn:disabled { opacity: 0.6; cursor: not-allowed; }
-.btn-ghost { padding: 10px 14px; border-radius: 8px; border: 1px solid var(--accent); background: transparent; color: var(--accent); cursor: pointer; }
+.btn-ghost { padding: 12px 16px; border-radius: 10px; border: 1px solid color-mix(in srgb, var(--accent) 60%, transparent); background: transparent; color: var(--fg); }
+.btn-ghost:hover { color: var(--fg); border-color: var(--accent); }
 
 /* Progress */
 .progress { height: 8px; border-radius: 999px; background: var(--bar-bg); overflow: hidden; }
-.bar { height: 100%; border-radius: 999px; background: var(--accent); }
+.bar { height: 100%; border-radius: 999px; background-image: var(--accent-grad); }
 
 /* Previews */
-.preview-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 10px; }
-.preview { position: relative; border: 1px solid var(--border); border-radius: 10px; overflow: hidden; background: repeating-conic-gradient(#0000 0 90deg, rgba(0,0,0,.04) 0 180deg) 0 0/16px 16px, #f8fafc; }
+.preview-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 12px; }
+.preview { position: relative; border: 1px solid var(--border); border-radius: 12px; overflow: hidden; background: repeating-conic-gradient(#0000 0 90deg, rgba(0,0,0,.04) 0 180deg) 0 0/16px 16px, #f8fafc; box-shadow: var(--shadow); }
 [data-theme='dark'] .preview { background: repeating-conic-gradient(#0000 0 90deg, rgba(255,255,255,.04) 0 180deg) 0 0/16px 16px, #0b0e14; }
-.preview img { display:block; width:100%; height: 160px; object-fit: contain; background: transparent; }
-.chip { position: absolute; top: 8px; left: 8px; background: rgba(0,0,0,0.6); color: #fff; font-size: 11px; padding: 3px 6px; border-radius: 999px; }
+.preview img { display:block; width:100%; height: 180px; object-fit: contain; background: transparent; }
+.chip { position: absolute; top: 8px; left: 8px; background: rgba(0,0,0,0.65); color: #fff; font-size: 11px; padding: 4px 8px; border-radius: 999px; backdrop-filter: blur(2px); }
+
+/* Terminal (logs) */
+.terminal {
+  width: 100%;
+  max-width: 100%;
+  background: var(--logs-bg);
+  color: var(--logs-fg);
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--logs-fg) 10%, transparent);
+  padding: 12px;
+  overflow: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.45;
+}

--- a/ui/src/theme.css
+++ b/ui/src/theme.css
@@ -1,0 +1,67 @@
+:root {
+  --bg: #f6f7f9;
+  --fg: #0a0a0a;
+  --muted: #666;
+  --accent: #0b6;
+  --bar-bg: #e6e6e6;
+  --card-bg: #fff;
+  --logs-bg: #0a0a0a;
+  --logs-fg: #e6e6e6;
+  --border: #e6e6e6;
+  --shadow: 0 4px 14px rgba(0,0,0,0.08);
+}
+
+:root[data-theme='dark'] {
+  --bg: #0b0e14;
+  --fg: #e6e6e6;
+  --muted: #a0a0a0;
+  --accent: #34d399;
+  --bar-bg: #2a2f3a;
+  --card-bg: #111827;
+  --logs-bg: #0a0a0a;
+  --logs-fg: #e6e6e6;
+  --border: #1f2937;
+  --shadow: 0 6px 20px rgba(0,0,0,0.25);
+}
+
+/* Layout */
+.container { max-width: 1200px; margin: 0 auto; padding: 24px; }
+.header { display:flex; align-items:center; justify-content:space-between; margin-bottom: 8px; }
+.subtitle { color: var(--muted); margin: 0; }
+
+/* Cards & Inputs */
+.card { margin-block: 16px; padding: 16px; border: 1px solid var(--border); border-radius: 12px; background: var(--card-bg); box-shadow: var(--shadow); }
+.label { display:block; font-size:12px; color: var(--muted); margin-bottom: 6px; }
+.input { width:100%; padding:10px 12px; border-radius:8px; border:1px solid var(--border); background: var(--card-bg); color: var(--fg); outline:none; }
+.row { display:grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.grid { display:grid; gap:12px; }
+
+/* Responsive layout */
+.two-col { display:grid; grid-template-columns: 280px 1fr; gap: 16px; }
+@media (max-width: 960px) {
+  .two-col { grid-template-columns: 1fr; }
+}
+
+/* Sticky actions (mobile-friendly) */
+.sticky-actions { position: sticky; bottom: 0; background: var(--bg); padding-top: 8px; margin-top: 8px; }
+
+/* Subtle transitions */
+.btn, .btn-ghost { transition: transform .05s ease, box-shadow .2s ease, background-color .2s ease, color .2s ease; }
+.btn:hover, .btn-ghost:hover { box-shadow: var(--shadow); }
+.btn:active, .btn-ghost:active { transform: translateY(1px); }
+
+/* Buttons */
+.btn { padding: 10px 14px; border-radius: 8px; border: 1px solid var(--accent); background: var(--accent); color: #fff; cursor: pointer; }
+.btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.btn-ghost { padding: 10px 14px; border-radius: 8px; border: 1px solid var(--accent); background: transparent; color: var(--accent); cursor: pointer; }
+
+/* Progress */
+.progress { height: 8px; border-radius: 999px; background: var(--bar-bg); overflow: hidden; }
+.bar { height: 100%; border-radius: 999px; background: var(--accent); }
+
+/* Previews */
+.preview-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 10px; }
+.preview { position: relative; border: 1px solid var(--border); border-radius: 10px; overflow: hidden; background: repeating-conic-gradient(#0000 0 90deg, rgba(0,0,0,.04) 0 180deg) 0 0/16px 16px, #f8fafc; }
+[data-theme='dark'] .preview { background: repeating-conic-gradient(#0000 0 90deg, rgba(255,255,255,.04) 0 180deg) 0 0/16px 16px, #0b0e14; }
+.preview img { display:block; width:100%; height: 160px; object-fit: contain; background: transparent; }
+.chip { position: absolute; top: 8px; left: 8px; background: rgba(0,0,0,0.6); color: #fff; font-size: 11px; padding: 3px 6px; border-radius: 999px; }

--- a/ui/src/utils.test.ts
+++ b/ui/src/utils.test.ts
@@ -1,0 +1,22 @@
+import {describe, it, expect} from 'vitest';
+import {parseResolutions, clampNumber} from './utils';
+
+describe('utils', () => {
+  it('parseResolutions splits and trims', () => {
+    expect(parseResolutions('1920x1080,  390x844,,  360x640')).toEqual([
+      '1920x1080',
+      '390x844',
+      '360x640',
+    ]);
+  });
+
+  it('parseResolutions handles empty input', () => {
+    expect(parseResolutions('')).toEqual([]);
+  });
+
+  it('clampNumber respects bounds', () => {
+    expect(clampNumber(5, 1, 10)).toBe(5);
+    expect(clampNumber(-1, 1, 10)).toBe(1);
+    expect(clampNumber(999, 1, 10)).toBe(10);
+  });
+});

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -1,0 +1,14 @@
+export function parseResolutions(input: string): string[] {
+  if (!input) return [];
+  return input
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => s.toLowerCase())
+    .map((s) => (s.includes('x') ? s : s.replace(/\s+/g, '')));
+}
+
+export function clampNumber(v: number, min: number, max: number): number {
+  if (Number.isNaN(v)) return min;
+  return Math.max(min, Math.min(max, v));
+}

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,0 +1,17 @@
+import {defineConfig} from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    open: true,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,13 +1,13 @@
-import { defineConfig } from 'vitest/config';
+import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
-    test: {
-        includeSource: ['src/**/*.ts'],
-        exclude: ['node_modules', 'dist'],
-        coverage: {
-            provider: 'v8',
-            reporter: ['text', 'lcov', 'html'],
-            exclude: ['**/*.test.ts', '**/*.spec.ts', '**/node_modules/**', '**/dist/**'],
-        },
+  test: {
+    includeSource: ['src/**/*.ts'],
+    exclude: ['node_modules', 'dist'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov', 'html'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', '**/node_modules/**', '**/dist/**'],
     },
+  },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,12 +2,15 @@ import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
   test: {
-    includeSource: ['src/**/*.ts'],
-    exclude: ['node_modules', 'dist'],
+    pool: 'forks',
+    singleThread: true,
+    include: ['src/**/*.test.ts', 'ui/src/**/*.test.ts'],
+    includeSource: ['src/**/*.ts', 'ui/src/**/*.ts', 'ui/src/**/*.tsx'],
+    exclude: ['**/node_modules/**', '**/dist/**', '**/.pnpm/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov', 'html'],
-      exclude: ['**/*.test.ts', '**/*.spec.ts', '**/node_modules/**', '**/dist/**'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', '**/node_modules/**', '**/dist/**', '**/.pnpm/**'],
     },
   },
 });


### PR DESCRIPTION
This PR introduces a local development experience for Crawl‑n‑Snap.

Highlights
- Web UI (React + Vite) under `ui/` for configuring runs, streaming logs, progress bars, and previewing results.
- Dev API server (Node HTTP) to spawn the CLI, stream logs via SSE, list runs, retrieve and download manifests, and open files/folders: `src/dev-server.ts`.
- Orchestrator script `scripts/dev.ts` to install UI deps (if missing) and launch both API + UI with one command.
- Sample static pages under `static/dev/` for quick sanity checks.
- README updated with Local Dev UI instructions and CLI/watch hints.

Usage
- `pnpm dev`: starts API on 3001 and Vite on 5173 (proxying /api).
- `pnpm dev:cli -- <args>`: watch the CLI with your arguments.

Notes
- Output and dev artifacts are ignored via .gitignore.
- Husky shows a deprecation notice for the older shim; follow-up can clean .husky if desired.

Let me know if you want the UI scaffold in a separate package/repo or more polish before merge.
