### PR TITLE
fix: bound concurrency and return complete, ordered results in limitConcurrency

### DIFF
--- a/src/concurrency.test.ts
+++ b/src/concurrency.test.ts
@@ -1,0 +1,79 @@
+import {describe, it, expect} from 'vitest';
+import {limitConcurrency} from './index';
+
+// A controllable deferred promise so tests can decide exactly when a task settles.
+function defer<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return {promise, resolve, reject};
+}
+
+describe('limitConcurrency', () => {
+  it('never runs more than `limit` tasks at once', async () => {
+    const limit = 3;
+    const total = 12;
+    let inFlight = 0;
+    let peak = 0;
+
+    const tasks = Array.from({length: total}, (_, i) => async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      // Yield a few microtasks so overlapping tasks actually coexist.
+      await new Promise((r) => setTimeout(r, 1));
+      inFlight--;
+      return i;
+    });
+
+    const results = await limitConcurrency(tasks, limit);
+
+    expect(peak).toBeLessThanOrEqual(limit);
+    expect(results).toHaveLength(total);
+  });
+
+  it('returns every result in input order regardless of completion order', async () => {
+    const deferreds = Array.from({length: 4}, () => defer<number>());
+    const tasks = deferreds.map((d) => () => d.promise);
+
+    const resultsPromise = limitConcurrency(tasks, 4);
+
+    // Resolve out of order: last task first, first task last.
+    deferreds[3].resolve(30);
+    deferreds[1].resolve(10);
+    deferreds[2].resolve(20);
+    deferreds[0].resolve(0);
+
+    const results = await resultsPromise;
+    expect(results).toEqual([0, 10, 20, 30]);
+  });
+
+  it('returns all results when there are more tasks than the limit', async () => {
+    const tasks = Array.from({length: 25}, (_, i) => async () => i * 2);
+    const results = await limitConcurrency(tasks, 4);
+    expect(results).toHaveLength(25);
+    expect(results).toEqual(Array.from({length: 25}, (_, i) => i * 2));
+  });
+
+  it('handles an empty task list', async () => {
+    const results = await limitConcurrency<number>([], 3);
+    expect(results).toEqual([]);
+  });
+
+  it('treats a non-positive limit as a single worker', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const tasks = Array.from({length: 5}, (_, i) => async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 1));
+      inFlight--;
+      return i;
+    });
+    const results = await limitConcurrency(tasks, 0);
+    expect(peak).toBe(1);
+    expect(results).toHaveLength(5);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,24 +223,31 @@ function createErrorSummary(url: string, error: any): ErrorSummary {
 
 // --- Main Logic ---
 
-// Helper function to limit concurrency using a semaphore-like approach
+// Helper function to limit concurrency using a semaphore-like approach.
+// Runs at most `limit` tasks at once, preserves input order in the returned
+// results array, and waits for every task to settle before resolving.
 async function limitConcurrency<T>(tasks: (() => Promise<T>)[], limit: number): Promise<T[]> {
-  const results: T[] = [];
-  const executing: Promise<void>[] = [];
+  const results: T[] = new Array(tasks.length);
+  const maxInFlight = Math.max(1, Math.floor(limit));
+  const executing = new Set<Promise<void>>();
 
-  for (const task of tasks) {
-    const promise = task().then((result) => {
-      results.push(result);
+  for (let idx = 0; idx < tasks.length; idx++) {
+    // Write each result into its input slot so ordering is deterministic
+    // regardless of which task finishes first.
+    const run = (async () => {
+      results[idx] = await tasks[idx]();
+    })();
+
+    // Track the in-flight promise and ensure it removes itself when settled,
+    // so the `executing` set accurately reflects the live workers.
+    const tracked: Promise<void> = run.finally(() => {
+      executing.delete(tracked);
     });
+    executing.add(tracked);
 
-    executing.push(promise);
-
-    if (executing.length >= limit) {
+    // Once we hit the cap, wait for at least one worker to free a slot.
+    if (executing.size >= maxInFlight) {
       await Promise.race(executing);
-      executing.splice(
-        executing.findIndex((p) => p === promise),
-        1
-      );
     }
   }
 
@@ -963,4 +970,4 @@ if (require.main === module) {
 }
 
 // Export for potential programmatic use (optional)
-export {runScreenshotter, CliOptions};
+export {runScreenshotter, CliOptions, limitConcurrency};


### PR DESCRIPTION
## Summary

`limitConcurrency` — the helper that runs per-resolution screenshot tasks with a `--concurrency` cap — is broken in two compounding ways. This PR rewrites it and adds regression tests.

This is **PR 1 of a multi-PR improvement series** derived from a full multi-agent audit (focus: performance + user improvements). It's the foundation for the performance work that follows, and a correctness fix in its own right.

## The bug

```ts
// before
const executing: Promise<void>[] = [];
for (const task of tasks) {
  const promise = task().then((result) => { results.push(result); });
  executing.push(promise);
  if (executing.length >= limit) {
    await Promise.race(executing);
    executing.splice(executing.findIndex((p) => p === promise), 1); // ← removes the JUST-PUSHED promise
  }
}
await Promise.all(executing);
```

After `Promise.race`, the code splices out `promise` — the task it *just added* — not the one that actually settled. So:

1. **The concurrency cap is silently ignored.** Settled promises pile up in `executing`; every later `Promise.race` resolves instantly, so once the first task finishes, all remaining tasks launch at once. `--concurrency 3` effectively becomes "unbounded" — a real problem on low-memory machines and large crawls.
2. **Results are incomplete and unordered.** `results` is filled in *completion* order, and the final `Promise.all(executing)` awaits a stale set. The returned array can be missing entries — which means the console summary **and the `run.json` manifest under-report which resolutions were actually captured**, the tool's headline multi-resolution feature.

## The fix

A self-removing `Set` of in-flight promises:

- Each task's result is written into its **input slot** (`results[idx] = await tasks[idx]()`), so ordering is deterministic regardless of which finishes first.
- Each tracked promise removes **itself** from the set in `.finally`, so the set always reflects live workers.
- We only `await Promise.race` once the set hits the cap, and `Promise.all` at the end waits for every task.
- A non-positive limit is clamped to a single worker.

## Tests

New `src/concurrency.test.ts` (and `limitConcurrency` is now exported):

- peak simultaneous in-flight never exceeds `limit`
- results are returned in **input order** even when tasks settle out of order (uses deferred promises)
- all results present when tasks ≫ limit
- empty list, and non-positive limit behave correctly

## Verification

- `tsc --noEmit` clean
- `vitest run` — 45 tests pass (40 existing + 5 new)
- `eslint` clean

## Risk

Low. Self-contained helper; behavior is now *more* correct (honors the cap, complete ordered results). No public API change beyond an added export.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)