### PR TITLE
fix: honor CLI/config precedence and report results truthfully

### DIFF
--- a/.crawlsnaprc.example.json
+++ b/.crawlsnaprc.example.json
@@ -5,6 +5,7 @@
   "crawl": false,
   "maxPages": 50,
   "timeout": 5000,
+  "navTimeout": 30000,
   "concurrency": 3,
   "retries": 2,
   "continueOnError": true,
@@ -12,7 +13,8 @@
   "mobile": false,
   "excludePatterns": ["*/admin/*", "*/login/*"],
   "includePatterns": ["*/products/*"],
-  "waitUntil": "networkidle",
+  "waitUntil": "load",
   "delay": 0,
-  "fullPage": true
+  "fullPage": true,
+  "headless": true
 }

--- a/README.md
+++ b/README.md
@@ -74,26 +74,32 @@ Arguments:
   url                      The full URL (including http/https) of the page to screenshot.
 
 Options:
-  -r, --resolution <WxH>   Custom screen resolution (e.g., 1920x1080). Repeatable.
-  -d, --desktop            Capture desktop resolutions (1920x1080)
-  -m, --mobile             Capture mobile resolutions (390x844)
+  -r, --resolution <WxH>   Custom screen resolution (e.g., 1920x1080). Repeatable. Replaces the default.
+  -d, --desktop            Add the desktop preset resolution (1920x1080)
+  -m, --mobile             Add the mobile preset resolution (390x844)
   -o, --output <dir>       Base output directory for screenshots (default: current directory)
   -b, --browser <name>     Browser to use (chromium, firefox, webkit) (default: "chromium")
   -c, --crawl              Enable crawling of all relative links on the website
   -p, --max-pages <n>      Maximum number of pages to crawl (only used with --crawl) (default: 50)
-  -t, --timeout <ms>       Early screenshot timeout in milliseconds (default: 5000, max Playwright timeout: 30000)
+  -t, --timeout <ms>       Early screenshot timeout: take the shot once this elapses even if still loading (default: 5000)
+  --nav-timeout <ms>       Hard navigation timeout: max time to wait for a page load before giving up (default: 30000)
   --concurrency <n>        Maximum number of concurrent screenshot operations (default: 3)
   -R, --retries <n>        Number of retry attempts for failed screenshots (default: 2)
   -x, --exclude-pattern    URL patterns to exclude from crawling (supports wildcards like */admin/*). Repeatable.
   -i, --include-pattern    URL patterns to include when crawling (supports wildcards). Repeatable.
-  --wait-until <state>     Navigation waitUntil (load | domcontentloaded | networkidle | commit) (default: networkidle)
+  --wait-until <state>     Navigation waitUntil (load | domcontentloaded | networkidle | commit) (default: load)
   --delay <ms>             Delay before screenshot after navigation/timeout (ms) (default: 0)
   --no-full-page           Capture only the visible viewport (default is full page)
+  --no-headless            Run the browser in headed mode (show the UI)
   --continue-on-error      Continue processing other URLs/resolutions when errors occur (default: true)
   --fail-fast              Stop processing immediately when any error occurs
   -V, --version            Output the version number
   -h, --help               Display help for command
 ```
+
+> Resolutions: if you pass one or more `-r` values they are used as-is (the
+> default 1920x1080 is **not** added). `--desktop`/`--mobile` add their preset
+> on top of whatever you provide. With no `-r` and no preset, 1920x1080 is used.
 
 ### Examples
 
@@ -137,7 +143,7 @@ npx @rosbel/crawl-n-snap https://example.com --browser firefox --output ./screen
 npx @rosbel/crawl-n-snap https://example.com --timeout 5000
 ```
 
-Note: The tool will attempt to take a screenshot after the specified timeout even if the page is still loading. Playwright has a fixed maximum timeout of 30 seconds for network idle.
+Note: `--timeout` is the _early screenshot_ cutoff — the tool takes the shot once it elapses even if the page is still loading. `--nav-timeout` (default 30000) is the _hard_ cap on how long Playwright waits for a page load before giving up.
 
 #### Use configuration file for project settings
 
@@ -155,9 +161,15 @@ If a `.crawlsnaprc.json` file exists in the current directory or home directory:
   "crawl": true,
   "maxPages": 20,
   "timeout": 7000,
+  "navTimeout": 30000,
   "concurrency": 2,
   "retries": 3,
   "continueOnError": true,
+  "waitUntil": "load",
+  "delay": 0,
+  "fullPage": true,
+  "headless": true,
+  "includePatterns": ["*/products/*"],
   "excludePatterns": ["*/admin/*", "*/login/*"]
 }
 ```
@@ -222,11 +234,17 @@ All CLI options can be specified in the configuration file. CLI options take pre
   "crawl": false,
   "maxPages": 50,
   "timeout": 5000,
+  "navTimeout": 30000,
   "concurrency": 3,
   "retries": 2,
   "continueOnError": true,
+  "waitUntil": "load",
+  "delay": 0,
+  "fullPage": true,
+  "headless": true,
   "desktop": false,
   "mobile": false,
+  "includePatterns": [],
   "excludePatterns": ["*/admin/*", "*/login/*", "*checkout*"]
 }
 ```

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -3,6 +3,9 @@ import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import {parseResolution} from './utils';
+// The real merge implementation, so these tests exercise production code rather
+// than a drifting copy.
+import {mergeConfigWithOptions, GetOptionSource} from './index';
 
 // Mock fs module
 vi.mock('fs/promises');
@@ -62,42 +65,6 @@ async function loadConfigFile(): Promise<ConfigFile | null> {
   }
 
   return null;
-}
-
-// Function to merge config file with CLI options (CLI takes precedence)
-function mergeConfigWithOptions(config: ConfigFile | null, cliOptions: any): any {
-  if (!config) return cliOptions;
-
-  // Merge exclude patterns from both CLI and config
-  const excludePatterns = [...(cliOptions.excludePattern || []), ...(config.excludePatterns || [])];
-
-  return {
-    resolution:
-      cliOptions.resolution.length === 1 &&
-      cliOptions.resolution[0].width === 1920 &&
-      cliOptions.resolution[0].height === 1080
-        ? config.resolutions?.map(parseResolution) || cliOptions.resolution // Use config if CLI has default
-        : cliOptions.resolution, // Use CLI if custom resolutions provided
-    output: cliOptions.output !== '.' ? cliOptions.output : config.output || cliOptions.output,
-    browser:
-      cliOptions.browser !== 'chromium' ? cliOptions.browser : config.browser || cliOptions.browser,
-    crawl: cliOptions.crawl || config.crawl || false,
-    maxPages:
-      cliOptions.maxPages !== 50 ? cliOptions.maxPages : config.maxPages || cliOptions.maxPages,
-    timeout:
-      cliOptions.timeout !== 5000 ? cliOptions.timeout : config.timeout || cliOptions.timeout,
-    concurrency:
-      cliOptions.concurrency !== 3
-        ? cliOptions.concurrency
-        : config.concurrency || cliOptions.concurrency,
-    retries: cliOptions.retries !== 2 ? cliOptions.retries : (config.retries ?? cliOptions.retries),
-    excludePattern: excludePatterns,
-    continueOnError: cliOptions.failFast
-      ? false
-      : (cliOptions.continueOnError ?? config.continueOnError ?? true),
-    desktop: cliOptions.desktop || config.desktop || false,
-    mobile: cliOptions.mobile || config.mobile || false,
-  };
 }
 
 describe('Configuration File Loading', () => {
@@ -196,121 +163,129 @@ describe('Configuration File Loading', () => {
 });
 
 describe('Configuration Merging', () => {
-  it('uses CLI options when no config file is provided', () => {
-    const cliOptions = {
-      resolution: [parseResolution('800x600')],
-      output: './custom',
-      browser: 'firefox',
-      crawl: true,
-      maxPages: 20,
-      timeout: 3000,
-      concurrency: 2,
-      retries: 1,
-      continueOnError: false,
-      excludePattern: ['*/admin/*'],
-      desktop: false,
-      mobile: true,
-      failFast: false,
-    };
-
-    const result = mergeConfigWithOptions(null, cliOptions);
-    expect(result).toEqual({
-      ...cliOptions,
-      excludePattern: ['*/admin/*'],
-    });
+  // A fully-populated CLI options object at its default values. Individual
+  // tests override fields and mark which ones the user "typed" via sources.
+  const baseCli = () => ({
+    resolution: [] as ReturnType<typeof parseResolution>[],
+    output: '.',
+    browser: 'chromium',
+    crawl: false,
+    maxPages: 50,
+    timeout: 5000,
+    navTimeout: 30000,
+    concurrency: 3,
+    retries: 2,
+    excludePattern: [] as string[],
+    includePattern: [] as string[],
+    continueOnError: true,
+    failFast: false,
+    desktop: false,
+    mobile: false,
+    waitUntil: 'load',
+    delay: 0,
+    fullPage: true,
+    headless: true,
   });
 
-  it('merges config file with CLI options (CLI takes precedence)', () => {
-    const config: ConfigFile = {
-      resolutions: ['1366x768', '390x844'],
-      browser: 'webkit',
-      output: './config-output',
-      crawl: false,
-      maxPages: 30,
-      timeout: 7000,
-      concurrency: 4,
-      retries: 3,
-      continueOnError: false,
-      excludePatterns: ['*/config-exclude/*'],
-    };
+  // Build a source lookup where the named options came from the CLI and
+  // everything else is at its default.
+  const cliSources =
+    (...cliNames: string[]): GetOptionSource =>
+    (name) =>
+      cliNames.includes(name) ? 'cli' : 'default';
 
-    const cliOptions = {
-      resolution: [parseResolution('800x600')], // Custom resolution - should override config
-      output: './cli-output', // Non-default - should override config
-      browser: 'chromium', // Default value - should use config
-      crawl: true, // Explicit true - should override config false
-      maxPages: 50, // Default value - should use config
-      timeout: 5000, // Default value - should use config
-      concurrency: 3, // Default value - should use config
-      retries: 2, // Default value - should use config
-      continueOnError: undefined, // Default value - should use config
-      excludePattern: ['*/cli-exclude/*'],
-      desktop: false,
-      mobile: false,
-      failFast: false,
-    };
-
-    const result = mergeConfigWithOptions(config, cliOptions);
-
-    expect(result.resolution).toEqual([parseResolution('800x600')]);
-    expect(result.output).toBe('./cli-output');
-    expect(result.browser).toBe('webkit'); // From config
-    expect(result.crawl).toBe(true); // From CLI (explicit true)
-    expect(result.maxPages).toBe(30); // From config (CLI has default)
-    expect(result.timeout).toBe(7000); // From config (CLI has default)
-    expect(result.concurrency).toBe(4); // From config (CLI has default)
-    expect(result.retries).toBe(3); // From config (CLI has default)
-    expect(result.continueOnError).toBe(false); // From config (CLI has undefined/default)
-    expect(result.excludePattern).toEqual(['*/cli-exclude/*', '*/config-exclude/*']); // Merged
+  it('returns CLI options unchanged when there is no config file', () => {
+    const cli = baseCli();
+    expect(mergeConfigWithOptions(null, cli)).toBe(cli);
   });
 
-  it('handles failFast option correctly', () => {
-    const config: ConfigFile = {
-      continueOnError: true,
-    };
+  it('fills unset CLI options from the config file', () => {
+    const result = mergeConfigWithOptions(
+      {browser: 'webkit', maxPages: 30, timeout: 7000, output: './from-config'},
+      baseCli(),
+      cliSources() // user typed nothing
+    );
+    expect(result.browser).toBe('webkit');
+    expect(result.maxPages).toBe(30);
+    expect(result.timeout).toBe(7000);
+    expect(result.output).toBe('./from-config');
+  });
 
-    const cliOptionsWithFailFast = {
-      resolution: [parseResolution('1920x1080')],
-      output: '.',
-      browser: 'chromium',
-      crawl: false,
-      maxPages: 50,
-      timeout: 5000,
-      concurrency: 3,
-      retries: 2,
-      continueOnError: true,
-      excludePattern: [],
-      desktop: false,
-      mobile: false,
-      failFast: true, // This should override continueOnError to false
-    };
+  it('lets an explicit CLI flag win over the config — even at a default-looking value', () => {
+    const result = mergeConfigWithOptions(
+      {timeout: 7000, browser: 'firefox'},
+      {...baseCli(), timeout: 5000, browser: 'chromium'},
+      cliSources('timeout', 'browser') // user explicitly passed both
+    );
+    // Previously the sentinel "=== 5000 means default" check let config win here.
+    expect(result.timeout).toBe(5000);
+    expect(result.browser).toBe('chromium');
+  });
 
-    const result = mergeConfigWithOptions(config, cliOptionsWithFailFast);
+  it('honors config fullPage/headless/continueOnError when the user passed no flag', () => {
+    const result = mergeConfigWithOptions(
+      {fullPage: false, headless: false, continueOnError: false},
+      baseCli(),
+      cliSources()
+    );
+    // These were previously dead because the CLI always supplied a boolean.
+    expect(result.fullPage).toBe(false);
+    expect(result.headless).toBe(false);
     expect(result.continueOnError).toBe(false);
   });
 
-  it('uses config resolutions when CLI has default resolution', () => {
-    const config: ConfigFile = {
-      resolutions: ['800x600', '1366x768'],
-    };
+  it('honors an explicit --no-full-page over a config fullPage:true', () => {
+    const result = mergeConfigWithOptions(
+      {fullPage: true},
+      {...baseCli(), fullPage: false},
+      cliSources('fullPage')
+    );
+    expect(result.fullPage).toBe(false);
+  });
 
-    const cliOptionsWithDefault = {
-      resolution: [parseResolution('1920x1080')], // Default resolution
-      output: '.',
-      browser: 'chromium',
-      crawl: false,
-      maxPages: 50,
-      timeout: 5000,
-      concurrency: 3,
-      retries: 2,
-      continueOnError: true,
-      excludePattern: [],
-      desktop: false,
-      mobile: false,
-      failFast: false,
-    };
+  it('forces continueOnError false when --fail-fast is set, regardless of config', () => {
+    const result = mergeConfigWithOptions(
+      {continueOnError: true},
+      {...baseCli(), failFast: true},
+      cliSources('failFast')
+    );
+    expect(result.continueOnError).toBe(false);
+  });
 
-    const result = mergeConfigWithOptions(config, cliOptionsWithDefault);
+  it('uses config resolutions when the user did not pass -r', () => {
+    const result = mergeConfigWithOptions(
+      {resolutions: ['800x600', '1366x768']},
+      baseCli(),
+      cliSources()
+    );
     expect(result.resolution).toEqual([parseResolution('800x600'), parseResolution('1366x768')]);
+  });
+
+  it('uses CLI -r resolutions over config resolutions', () => {
+    const result = mergeConfigWithOptions(
+      {resolutions: ['800x600']},
+      {...baseCli(), resolution: [parseResolution('1280x720')]},
+      cliSources('resolution')
+    );
+    expect(result.resolution).toEqual([parseResolution('1280x720')]);
+  });
+
+  it('merges exclude and include patterns from both CLI and config', () => {
+    const result = mergeConfigWithOptions(
+      {excludePatterns: ['*/config-x/*'], includePatterns: ['*/config-i/*']},
+      {...baseCli(), excludePattern: ['*/cli-x/*'], includePattern: ['*/cli-i/*']},
+      cliSources('excludePattern', 'includePattern')
+    );
+    expect(result.excludePattern).toEqual(['*/cli-x/*', '*/config-x/*']);
+    expect(result.includePattern).toEqual(['*/cli-i/*', '*/config-i/*']);
+  });
+
+  it('ignores an invalid waitUntil from config and keeps the CLI value', () => {
+    const result = mergeConfigWithOptions(
+      {waitUntil: 'not-a-state'},
+      {...baseCli(), waitUntil: 'load'},
+      cliSources()
+    );
+    expect(result.waitUntil).toBe('load');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,58 +105,65 @@ async function loadConfigFile(): Promise<ConfigFile | null> {
   return null;
 }
 
-// Function to merge config file with CLI options (CLI takes precedence)
-function mergeConfigWithOptions(config: ConfigFile | null, cliOptions: any): any {
+// Where a Commander option's value came from (e.g. 'cli', 'default', 'config').
+// Mirrors the return of program.getOptionValueSource(); injected so the merge
+// is unit-testable without depending on Commander's global parse state.
+type GetOptionSource = (name: string) => string | undefined;
+
+// Fallback used when no source information is available (treat everything as
+// at its default, so config values win wherever present).
+const allDefaultSources: GetOptionSource = () => 'default';
+
+// Merge a loaded config file with parsed CLI options. Precedence is:
+//   explicit CLI flag  >  config file value  >  CLI default.
+// `getSource` tells us whether the user actually typed an option (source
+// 'cli') versus it sitting at its default — without it we could not tell an
+// explicit `--timeout 5000` apart from the 5000 default, which previously let
+// the config file override values the user had explicitly set.
+function mergeConfigWithOptions(
+  config: ConfigFile | null,
+  cliOptions: any,
+  getSource: GetOptionSource = allDefaultSources
+): any {
   if (!config) return cliOptions;
 
-  // Merge exclude patterns from both CLI and config
+  // Merge list options from both CLI and config (additive, not override).
   const excludePatterns = [...(cliOptions.excludePattern || []), ...(config.excludePatterns || [])];
   const includePatterns = [...(cliOptions.includePattern || []), ...(config.includePatterns || [])];
 
-  const allowedWaitUntil = ['load', 'domcontentloaded', 'networkidle', 'commit'] as const;
-  const safeWaitUntil = (val: any) =>
-    allowedWaitUntil.includes(val) ? val : (undefined as unknown as never);
+  const allowedWaitUntil = ['load', 'domcontentloaded', 'networkidle', 'commit'];
+  const safeWaitUntil = (val: any) => (allowedWaitUntil.includes(val) ? val : undefined);
+
+  const fromCli = (name: string) => getSource(name) === 'cli';
+  // CLI value if the user set it, else the config value when present, else the
+  // CLI default. `??` (not `||`) so legitimate falsy values like 0 / false from
+  // the config are honored.
+  const pick = <T>(name: string, cliValue: T, configValue: T | undefined): T =>
+    fromCli(name) ? cliValue : (configValue ?? cliValue);
 
   return {
-    resolution:
-      cliOptions.resolution.length === 1 &&
-      cliOptions.resolution[0].width === 1920 &&
-      cliOptions.resolution[0].height === 1080
-        ? config.resolutions?.map(parseResolution) || cliOptions.resolution // Use config if CLI has default
-        : cliOptions.resolution, // Use CLI if custom resolutions provided
-    output: cliOptions.output !== '.' ? cliOptions.output : config.output || cliOptions.output,
-    browser:
-      cliOptions.browser !== 'chromium' ? cliOptions.browser : config.browser || cliOptions.browser,
-    crawl: cliOptions.crawl || config.crawl || false,
-    maxPages:
-      cliOptions.maxPages !== 50 ? cliOptions.maxPages : config.maxPages || cliOptions.maxPages,
-    timeout:
-      cliOptions.timeout !== 5000 ? cliOptions.timeout : config.timeout || cliOptions.timeout,
-    navTimeout:
-      cliOptions.navTimeout !== 30000
-        ? cliOptions.navTimeout
-        : (config.navTimeout ?? cliOptions.navTimeout),
-    concurrency:
-      cliOptions.concurrency !== 3
-        ? cliOptions.concurrency
-        : config.concurrency || cliOptions.concurrency,
-    retries: cliOptions.retries !== 2 ? cliOptions.retries : (config.retries ?? cliOptions.retries),
+    resolution: fromCli('resolution')
+      ? cliOptions.resolution
+      : (config.resolutions?.map(parseResolution) ?? cliOptions.resolution),
+    output: pick('output', cliOptions.output, config.output),
+    browser: pick('browser', cliOptions.browser, config.browser),
+    crawl: pick('crawl', cliOptions.crawl, config.crawl),
+    maxPages: pick('maxPages', cliOptions.maxPages, config.maxPages),
+    timeout: pick('timeout', cliOptions.timeout, config.timeout),
+    navTimeout: pick('navTimeout', cliOptions.navTimeout, config.navTimeout),
+    concurrency: pick('concurrency', cliOptions.concurrency, config.concurrency),
+    retries: pick('retries', cliOptions.retries, config.retries),
     excludePattern: excludePatterns,
     includePattern: includePatterns,
     continueOnError: cliOptions.failFast
       ? false
-      : (cliOptions.continueOnError ?? config.continueOnError ?? true),
-    desktop: cliOptions.desktop || config.desktop || false,
-    mobile: cliOptions.mobile || config.mobile || false,
-    waitUntil:
-      cliOptions.waitUntil !== 'load'
-        ? cliOptions.waitUntil
-        : safeWaitUntil(config.waitUntil) || cliOptions.waitUntil,
-    delay: cliOptions.delay !== 0 ? cliOptions.delay : (config.delay ?? cliOptions.delay),
-    fullPage:
-      typeof cliOptions.fullPage === 'boolean' ? cliOptions.fullPage : (config.fullPage ?? true),
-    headless:
-      typeof cliOptions.headless === 'boolean' ? cliOptions.headless : (config.headless ?? true),
+      : pick('continueOnError', cliOptions.continueOnError, config.continueOnError),
+    desktop: pick('desktop', cliOptions.desktop, config.desktop),
+    mobile: pick('mobile', cliOptions.mobile, config.mobile),
+    waitUntil: pick('waitUntil', cliOptions.waitUntil, safeWaitUntil(config.waitUntil)),
+    delay: pick('delay', cliOptions.delay, config.delay),
+    fullPage: pick('fullPage', cliOptions.fullPage, config.fullPage),
+    headless: pick('headless', cliOptions.headless, config.headless),
   };
 }
 
@@ -261,17 +268,21 @@ async function limitConcurrency<T>(tasks: (() => Promise<T>)[], limit: number): 
   return results;
 }
 
-// Helper function to retry operations with exponential backoff
+// Helper function to retry operations with exponential backoff. Returns the
+// operation's value along with how many attempts it actually took (1 = first
+// try succeeded), so callers can report retries truthfully instead of assuming
+// the maximum.
 async function retryWithBackoff<T>(
   operation: () => Promise<T>,
   maxRetries: number,
   baseDelay: number = 1000
-): Promise<T> {
+): Promise<{value: T; attempts: number}> {
   let lastError: Error = new Error('No attempts made');
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
-      return await operation();
+      const value = await operation();
+      return {value, attempts: attempt + 1};
     } catch (error: any) {
       lastError = error instanceof Error ? error : new Error(String(error));
 
@@ -388,7 +399,9 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
   try {
     new URL(targetUrl); // Validate URL format early
   } catch (error: any) {
-    console.error(`Invalid URL: ${error.message}`);
+    // Fail fast instead of launching a browser and crashing later with a less
+    // helpful error deeper in the run.
+    throw new Error(`Invalid URL "${targetUrl}": ${error.message}`);
   }
 
   // Parse string resolutions to Resolution objects
@@ -570,14 +583,16 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
               return {
                 success: true,
                 resolution: resolutionString,
-                outputPath: result.outputPath,
-                attempts: options.retries + 1,
+                outputPath: result.value.outputPath,
+                // Real number of attempts (1 = succeeded on the first try).
+                attempts: result.attempts,
               };
             } catch (error: any) {
               return {
                 success: false,
                 resolution: resolutionString,
                 error: error.message,
+                // Failure path exhausts every attempt.
                 attempts: options.retries + 1,
               };
             }
@@ -700,7 +715,7 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
           console.log(`  ${index + 1}. [${error.type}] ${error.url}: ${error.error}`);
         });
       } else {
-        console.log('\nFirst 10 errors (use --continue-on-error=false to stop on first error):');
+        console.log('\nFirst 10 errors (use --fail-fast to stop on the first error):');
         errorSummaries.slice(0, 10).forEach((error, index) => {
           console.log(`  ${index + 1}. [${error.type}] ${error.url}: ${error.error}`);
         });
@@ -798,12 +813,12 @@ program
   .argument('<url>', 'The full URL (including http/https) of the page to screenshot.')
   .option<Resolution[]>(
     '-r, --resolution <WxH>',
-    'Custom screen resolution (e.g., 1920x1080). Repeatable.',
+    'Custom screen resolution (e.g., 1920x1080). Repeatable. If omitted (and no preset), defaults to 1920x1080.',
     collectResolutions,
-    [parseResolution('1920x1080')] // Default if no preset or custom resolution provided
+    [] // Start empty; the default 1920x1080 is applied only when nothing else is provided
   )
-  .option('-d, --desktop', 'Capture desktop resolutions (1920x1080, 1366x768, 1440x900)')
-  .option('-m, --mobile', 'Capture mobile resolutions (375x667, 390x844, 360x640)')
+  .option('-d, --desktop', 'Add the desktop preset resolution (1920x1080)')
+  .option('-m, --mobile', 'Add the mobile preset resolution (390x844)')
   .option('-o, --output <dir>', 'Base output directory for screenshots', '.') // Default to current directory
   .option<SupportedBrowser>(
     '-b, --browser <name>',
@@ -819,7 +834,7 @@ program
   )
   .option('-c, --crawl', 'Enable crawling of all relative links on the website', false)
   .option(
-    '-p, --max-pages <name>',
+    '-p, --max-pages <n>',
     'Maximum number of pages to crawl (only used with --crawl)',
     (value) => {
       const parsed = parseInt(value, 10);
@@ -954,11 +969,23 @@ program
         // Load configuration file first
         const configFile = await loadConfigFile();
 
-        // Merge config file with CLI options (CLI takes precedence)
-        const mergedOptions = mergeConfigWithOptions(configFile, options);
+        // Merge config file with CLI options (explicit CLI flags win over config,
+        // which wins over CLI defaults). Pass Commander's option-source lookup so
+        // the merge can tell an explicit flag apart from a default.
+        const mergedOptions = mergeConfigWithOptions(configFile, options, (name) =>
+          program.getOptionValueSource(name)
+        );
 
-        // Handle device presets
-        let resolutions = [...mergedOptions.resolution]; // Start with merged resolutions
+        // Did the user actually choose resolutions (via -r or the config file)?
+        const resolutionFromCli = program.getOptionValueSource('resolution') === 'cli';
+        const resolutionFromConfig =
+          !resolutionFromCli &&
+          Array.isArray(configFile?.resolutions) &&
+          configFile.resolutions.length > 0;
+        const userChoseResolutions = resolutionFromCli || resolutionFromConfig;
+
+        // Start from the user's explicit resolutions (if any), then layer presets.
+        let resolutions = [...mergedOptions.resolution];
 
         if (mergedOptions.desktop) {
           resolutions = [...resolutions, ...devicePresets.desktop];
@@ -966,6 +993,13 @@ program
 
         if (mergedOptions.mobile) {
           resolutions = [...resolutions, ...devicePresets.mobile];
+        }
+
+        // Fall back to the single default resolution only when the user neither
+        // chose resolutions nor selected a preset — so `--mobile` alone no longer
+        // silently also captures 1920x1080.
+        if (resolutions.length === 0 && !userChoseResolutions) {
+          resolutions = [parseResolution('1920x1080')];
         }
 
         // Remove duplicates (based on width and height)
@@ -1006,6 +1040,18 @@ program
     }
   );
 
+program.addHelpText(
+  'after',
+  `
+Examples:
+  $ crawl-n-snap https://example.com
+  $ crawl-n-snap https://example.com -r 1440x900 -r 390x844
+  $ crawl-n-snap https://example.com --desktop --mobile
+  $ crawl-n-snap https://example.com --crawl --max-pages 25 -x "*/admin/*"
+  $ crawl-n-snap https://example.com --wait-until networkidle --delay 500
+  $ crawl-n-snap https://example.com -o ./shots --no-full-page`
+);
+
 // Only parse args if the script is run directly
 if (require.main === module) {
   program.parseAsync(process.argv).catch((err) => {
@@ -1014,5 +1060,12 @@ if (require.main === module) {
   });
 }
 
-// Export for potential programmatic use (optional)
-export {runScreenshotter, CliOptions, limitConcurrency};
+// Export for potential programmatic use and unit testing.
+export {
+  runScreenshotter,
+  CliOptions,
+  limitConcurrency,
+  retryWithBackoff,
+  mergeConfigWithOptions,
+  GetOptionSource,
+};

--- a/src/retry.test.ts
+++ b/src/retry.test.ts
@@ -1,0 +1,43 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {retryWithBackoff} from './index';
+
+describe('retryWithBackoff', () => {
+  beforeEach(() => {
+    // The helper logs retry progress; keep test output clean.
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reports attempts=1 when the operation succeeds on the first try', async () => {
+    const op = vi.fn(async () => 'ok');
+    const {value, attempts} = await retryWithBackoff(op, 2, 0);
+    expect(value).toBe('ok');
+    expect(attempts).toBe(1);
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts the real number of attempts across retries', async () => {
+    let calls = 0;
+    const op = vi.fn(async () => {
+      calls++;
+      if (calls < 3) throw new Error('transient');
+      return 'recovered';
+    });
+    // baseDelay 0 so the exponential backoff does not slow the test down.
+    const {value, attempts} = await retryWithBackoff(op, 5, 0);
+    expect(value).toBe('recovered');
+    expect(attempts).toBe(3);
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws the last error after exhausting all retries', async () => {
+    const op = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    await expect(retryWithBackoff(op, 2, 0)).rejects.toThrow('boom');
+    // maxRetries=2 means 1 initial attempt + 2 retries = 3 calls.
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary

A cluster of "what you set is silently ignored or misreported" defects in the CLI's option handling. **PR 3 of the series**, stacked on #13 (`perf/single-navigation`).

## Fixes

### Config precedence (the core bug)
`mergeConfigWithOptions` guessed whether an option was user-supplied by comparing it to its default (`cliOptions.timeout !== 5000`). So **explicitly passing the default** (`--timeout 5000`) was indistinguishable from not passing it, letting the **config file override values the user explicitly set** — the opposite of the documented precedence. It's now driven by Commander's `getOptionValueSource` (injected as a parameter so the function stays pure and unit-testable): **explicit CLI flag > config file > CLI default**. Switched `||` → `??` so falsy config values (`0` / `false`) are honored.

### Dead config keys now work
`fullPage`, `headless`, and `continueOnError` from the config file were **never applied** because Commander always supplies a boolean for them (the old `typeof === 'boolean' ? cli : config` checks never fell through). They now respect the option source like everything else.

### Device presets no longer leak the default resolution
The `-r` default was a literal `[1920x1080]`, so:
- `--mobile` alone produced **1920×1080 AND 390×844** (you wanted just mobile)
- `-r 800x600` produced **1920×1080 AND 800×600**

The default is now empty; explicit `-r`/config resolutions are used as-is, presets layer on top, and `1920×1080` is applied only when the user provided neither.

> **Behavior change:** a custom `-r` now **replaces** the default instead of adding to it.

### Truthful retry reporting
`retryWithBackoff` now returns `{value, attempts}`; the success path reports the **real** attempt count. First-try successes no longer print a bogus `(after 2 retries)` (you can see this in #13's screenshots — every success said "after 2 retries").

### Smaller fixes
- Invalid target URL **fails fast** (throws) instead of logging and continuing to launch a browser.
- Error-summary hint references the real flag (`--fail-fast`), not the non-existent `--continue-on-error=false`.
- Help: preset descriptions match what's actually captured, `--max-pages <name>` → `<n>`, and an **Examples** section was added.

## Tests
- `config.test.ts` now **imports and exercises the real `mergeConfigWithOptions`** — the previous tests validated a *drifting recreated copy* (it still used the old sentinel logic), giving false confidence. New cases cover precedence, the dead-config fixes, `--fail-fast`, resolution selection, and pattern merging.
- New `retry.test.ts` asserts accurate attempt counting and exhaustion.

## Docs
`README.md` + `.crawlsnaprc.example.json` updated for `--nav-timeout`, `--no-headless`, the new `--wait-until` default (`load`), the resolution behavior, and previously-missing config keys (`includePatterns`, `waitUntil`, `delay`, `fullPage`, `headless`).

## Verification
Ran the **real CLI**: `--mobile` alone → only 390×844; `-r 800x600` → only 800×600; no args → 1920×1080; first-try success prints no retry text; invalid URL exits with a clear message. `tsc` clean, **54 tests pass**, `eslint` clean.

## Risk
Low–medium. The merge rewrite is the riskiest piece and is now covered by real unit tests against production code. The resolution behavior change is intentional and documented.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)