### PR TITLE
feat: device emulation and authentication

### DIFF
--- a/.changeset/device-emulation-and-auth.md
+++ b/.changeset/device-emulation-and-auth.md
@@ -1,0 +1,17 @@
+---
+'@rosbel/crawl-n-snap': minor
+---
+
+Add device emulation and authentication, all wired through the browser context:
+
+- `--device <name>` — emulate a Playwright device (e.g. "iPhone 13"); sets the
+  viewport, DPR, touch, and User-Agent, and captures a single shot (overrides `-r`).
+- `--color-scheme <light|dark|no-preference>` — emulate `prefers-color-scheme`.
+- `--scale <n>` — device scale factor / DPR (e.g. `2` for retina).
+- `--user-agent <string>` — override the User-Agent.
+- `--header <name:value>` (repeatable), `--basic-auth <user:pass>`, and
+  `--storage-state <file>` — screenshot pages behind tokens, HTTP Basic auth, or a
+  saved login session.
+
+Secret values (auth, headers, storage state) are never printed to the console or
+written to `run.json` — only a boolean/count is recorded.

--- a/.crawlsnaprc.example.json
+++ b/.crawlsnaprc.example.json
@@ -16,5 +16,7 @@
   "waitUntil": "load",
   "delay": 0,
   "fullPage": true,
-  "headless": true
+  "headless": true,
+  "scale": 1,
+  "colorScheme": "light"
 }

--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ Options:
   --clip <x,y,w,h>         Capture only a fixed region of the page (e.g. 0,0,800,600)
   --wait-for-selector <css>  Wait for this CSS selector before capturing
   --disable-animations     Freeze CSS animations/transitions for stable screenshots
+  --scale <n>              Device scale factor / DPR (e.g. 2 for retina). Default: 1
+  --color-scheme <scheme>  Emulate prefers-color-scheme (light | dark | no-preference)
+  --user-agent <string>    Override the browser User-Agent string
+  --device <name>          Emulate a Playwright device (e.g. "iPhone 13"); overrides -r
+  --header <name:value>    Extra HTTP header to send. Repeatable.
+  --basic-auth <user:pass> HTTP Basic auth credentials for gated pages
+  --storage-state <file>   Load cookies/localStorage from a Playwright storageState file
   --continue-on-error      Continue processing other URLs/resolutions when errors occur (default: true)
   --fail-fast              Stop processing immediately when any error occurs
   -V, --version            Output the version number
@@ -226,6 +233,26 @@ Notes:
 
 - `--selector` and `--clip` are mutually exclusive, and both take precedence over `--full-page`.
 - `--quality` only applies to `--format jpeg`.
+
+#### Device emulation, dark mode, and authentication
+
+```bash
+# Retina (2x) screenshots
+npx @rosbel/crawl-n-snap https://example.com --scale 2
+
+# Dark mode
+npx @rosbel/crawl-n-snap https://example.com --color-scheme dark
+
+# Emulate a real device (sets viewport, DPR, touch, and UA; -r is ignored)
+npx @rosbel/crawl-n-snap https://example.com --device "iPhone 13"
+
+# Screenshot pages behind HTTP Basic auth, a bearer token, or a saved session
+npx @rosbel/crawl-n-snap https://example.com --basic-auth "user:pass"
+npx @rosbel/crawl-n-snap https://example.com --header "Authorization: Bearer <token>"
+npx @rosbel/crawl-n-snap https://example.com --storage-state ./auth.json
+```
+
+Secrets (`--basic-auth`, `--header`, `--storage-state`) are never printed to the console or written to `run.json` (only a boolean/count is recorded).
 
 ## Output Structure
 

--- a/src/dev-server.ts
+++ b/src/dev-server.ts
@@ -133,6 +133,13 @@ function optionsToArgs(payload: any): string[] {
   if (payload.clip) args.push('--clip', String(payload.clip));
   if (payload.waitForSelector) args.push('--wait-for-selector', String(payload.waitForSelector));
   if (payload.disableAnimations) args.push('--disable-animations');
+  if (payload.scale != null) args.push('--scale', String(payload.scale));
+  if (payload.colorScheme) args.push('--color-scheme', String(payload.colorScheme));
+  if (payload.userAgent) args.push('--user-agent', String(payload.userAgent));
+  if (payload.device) args.push('--device', String(payload.device));
+  (payload.headers || []).forEach((h: string) => args.push('--header', h));
+  if (payload.basicAuth) args.push('--basic-auth', String(payload.basicAuth));
+  if (payload.storageState) args.push('--storage-state', String(payload.storageState));
   return args;
 }
 

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -136,6 +136,7 @@ async function main() {
     headless,
     format: format as 'png' | 'jpeg',
     disableAnimations,
+    scale: 1,
   };
 
   await runScreenshotter(url, options);

--- a/src/emulation.test.ts
+++ b/src/emulation.test.ts
@@ -1,0 +1,31 @@
+import {describe, it, expect} from 'vitest';
+import {parseHeaders, parseBasicAuth} from './index';
+
+describe('parseHeaders', () => {
+  it('parses "Name: value" pairs, splitting on the first colon', () => {
+    expect(parseHeaders(['X-Test: 1', 'Authorization: Bearer a:b:c'])).toEqual({
+      'X-Test': '1',
+      Authorization: 'Bearer a:b:c',
+    });
+  });
+
+  it('trims whitespace around name and value', () => {
+    expect(parseHeaders(['  X-A :  hello world  '])).toEqual({'X-A': 'hello world'});
+  });
+
+  it('throws on a header without a colon or with an empty name', () => {
+    expect(() => parseHeaders(['no-colon'])).toThrow(/Name: value/);
+    expect(() => parseHeaders([': value'])).toThrow(/empty/);
+  });
+});
+
+describe('parseBasicAuth', () => {
+  it('splits user:password on the first colon (password may contain colons)', () => {
+    expect(parseBasicAuth('user:pa:ss')).toEqual({username: 'user', password: 'pa:ss'});
+    expect(parseBasicAuth('alice:secret')).toEqual({username: 'alice', password: 'secret'});
+  });
+
+  it('throws when there is no colon', () => {
+    expect(() => parseBasicAuth('nopassword')).toThrow(/username:password/);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 // src/index.ts
 
 import {program} from 'commander';
-import playwright, {BrowserType, Page} from 'playwright';
+import playwright, {BrowserType, Page, BrowserContextOptions} from 'playwright';
 import path from 'path';
 import fs from 'fs/promises';
 import fsSync from 'fs';
@@ -44,6 +44,13 @@ interface CliOptions {
   clip?: ClipRegion;
   waitForSelector?: string;
   disableAnimations: boolean;
+  scale: number;
+  colorScheme?: 'light' | 'dark' | 'no-preference';
+  userAgent?: string;
+  device?: string;
+  headers?: Record<string, string>;
+  basicAuth?: {username: string; password: string};
+  storageState?: string;
 }
 
 interface ClipRegion {
@@ -85,6 +92,13 @@ interface ConfigFile {
   clip?: string;
   waitForSelector?: string;
   disableAnimations?: boolean;
+  scale?: number;
+  colorScheme?: 'light' | 'dark' | 'no-preference' | string;
+  userAgent?: string;
+  device?: string;
+  headers?: string[];
+  basicAuth?: string;
+  storageState?: string;
 }
 
 // Parse a --clip value "x,y,width,height" into a region. x/y must be >= 0 and
@@ -105,6 +119,32 @@ function parseClip(value: string): ClipRegion {
     throw new Error(`Invalid --clip "${value}". x,y must be >= 0 and width,height > 0.`);
   }
   return {x, y, width, height};
+}
+
+// Parse "Name: value" header strings into a header map. Splits on the first
+// colon so values may themselves contain colons.
+function parseHeaders(list: string[]): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const raw of list) {
+    const idx = raw.indexOf(':');
+    if (idx === -1) {
+      throw new Error(`Invalid --header "${raw}". Use "Name: value".`);
+    }
+    const name = raw.slice(0, idx).trim();
+    const value = raw.slice(idx + 1).trim();
+    if (!name) throw new Error(`Invalid --header "${raw}". Header name is empty.`);
+    headers[name] = value;
+  }
+  return headers;
+}
+
+// Parse "user:password" basic-auth credentials (password may contain colons).
+function parseBasicAuth(value: string): {username: string; password: string} {
+  const idx = value.indexOf(':');
+  if (idx === -1) {
+    throw new Error('Invalid --basic-auth. Use "username:password".');
+  }
+  return {username: value.slice(0, idx), password: value.slice(idx + 1)};
 }
 
 // --- Configuration File Support ---
@@ -213,6 +253,14 @@ function mergeConfigWithOptions(
       cliOptions.disableAnimations,
       config.disableAnimations
     ),
+    scale: pick('scale', cliOptions.scale, config.scale),
+    colorScheme: pick('colorScheme', cliOptions.colorScheme, config.colorScheme),
+    userAgent: pick('userAgent', cliOptions.userAgent, config.userAgent),
+    device: pick('device', cliOptions.device, config.device),
+    // Headers merge additively (CLI first, then config).
+    header: [...(cliOptions.header || []), ...(config.headers || [])],
+    basicAuth: pick('basicAuth', cliOptions.basicAuth, config.basicAuth),
+    storageState: pick('storageState', cliOptions.storageState, config.storageState),
   };
 }
 
@@ -479,6 +527,20 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
       `${options.disableAnimations ? '; animations disabled' : ''}` +
       `${options.waitForSelector ? `; wait-for: ${options.waitForSelector}` : ''}`
   );
+  // Emulation/auth banner. Never print secret values (auth, headers, storage).
+  const emulationBits: string[] = [];
+  if (options.device) emulationBits.push(`device: ${options.device}`);
+  if (options.scale && options.scale !== 1) emulationBits.push(`scale: ${options.scale}x`);
+  if (options.colorScheme) emulationBits.push(`color-scheme: ${options.colorScheme}`);
+  if (options.userAgent) emulationBits.push('custom user-agent');
+  if (emulationBits.length) console.log(`Emulation: ${emulationBits.join('; ')}`);
+  const authBits: string[] = [];
+  if (options.basicAuth) authBits.push('basic-auth');
+  if (options.headers && Object.keys(options.headers).length) {
+    authBits.push(`${Object.keys(options.headers).length} custom header(s)`);
+  }
+  if (options.storageState) authBits.push('storage-state');
+  if (authBits.length) console.log(`Auth: ${authBits.join('; ')} (values hidden)`);
   console.log(`Headless: ${options.headless}`);
   console.log(`Crawl Mode: ${options.crawl ? 'Enabled' : 'Disabled'}`);
   if (options.crawl) {
@@ -505,9 +567,40 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
     const browserType: BrowserType = playwright[options.browser];
     console.log(`Launching ${options.browser}...`);
     browser = await browserType.launch({headless: options.headless});
-    const context = await browser.newContext();
+
+    // Build context options for emulation/auth. Start from a device descriptor
+    // (if --device), then layer explicit overrides on top. Only keys the user
+    // actually set are included, so the no-flag path stays a plain context.
+    const deviceDescriptor = options.device ? playwright.devices[options.device] : undefined;
+    const contextOptions: BrowserContextOptions = {...(deviceDescriptor || {})};
+    if (options.scale && options.scale !== 1) contextOptions.deviceScaleFactor = options.scale;
+    if (options.colorScheme) contextOptions.colorScheme = options.colorScheme;
+    if (options.userAgent) contextOptions.userAgent = options.userAgent;
+    if (options.headers && Object.keys(options.headers).length) {
+      contextOptions.extraHTTPHeaders = options.headers;
+    }
+    if (options.basicAuth) contextOptions.httpCredentials = options.basicAuth;
+    if (options.storageState) contextOptions.storageState = options.storageState;
+
+    const context = await browser.newContext(contextOptions);
     const page = await context.newPage();
     console.log('Browser launched successfully.');
+
+    // When emulating a device, the descriptor defines the viewport/DPR/touch, so
+    // capture a single shot labeled by the device instead of iterating -r sizes.
+    const useDeviceViewport = Boolean(deviceDescriptor);
+    type CaptureTarget = {label: string; viewport?: {width: number; height: number}};
+    const captureTargets: CaptureTarget[] = useDeviceViewport
+      ? [
+          {
+            label:
+              options.device!.replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_+|_+$/g, '') || 'device',
+          },
+        ]
+      : parsedResolutions.map((r) => ({
+          label: `${r.width}x${r.height}`,
+          viewport: {width: r.width, height: r.height},
+        }));
 
     // Track visited URLs to avoid loops (using normalized URLs)
     const visitedUrls = new Set<string>();
@@ -588,26 +681,28 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
           );
         }
 
-        // Process all resolutions with controlled concurrency for better performance
+        // Process all capture targets with controlled concurrency for better performance
         console.log(
-          `\nProcessing ${parsedResolutions.length} resolutions (max ${options.concurrency} concurrent)...`
+          `\nProcessing ${captureTargets.length} ${useDeviceViewport ? 'capture' : 'resolutions'} (max ${options.concurrency} concurrent)...`
         );
 
-        const screenshotTasks = parsedResolutions.map((resolution) => {
-          const {width, height} = resolution;
-          const resolutionString = `${width}x${height}`;
+        const screenshotTasks = captureTargets.map((target) => {
+          const resolutionString = target.label;
 
           return async () => {
             try {
               // Wrap screenshot operation in retry logic
               const result = await retryWithBackoff(async () => {
-                // Create a new page for each resolution to avoid conflicts
+                // Create a new page for each target to avoid conflicts
                 const resolutionPage = await context.newPage();
 
                 try {
                   // Set the viewport BEFORE navigating so responsive layouts and
                   // width-based media queries render at the target resolution.
-                  await resolutionPage.setViewportSize({width, height});
+                  // (Skipped when a --device descriptor already sets the viewport.)
+                  if (target.viewport) {
+                    await resolutionPage.setViewportSize(target.viewport);
+                  }
 
                   // Navigate, racing the early-screenshot timeout against the
                   // hard navigation cap (see navigateWithEarlyTimeout).
@@ -864,9 +959,17 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
         clip: options.clip,
         waitForSelector: options.waitForSelector,
         disableAnimations: options.disableAnimations,
+        scale: options.scale,
+        colorScheme: options.colorScheme,
+        userAgent: options.userAgent,
+        device: options.device,
+        // Auth/secret values are deliberately recorded only as booleans/counts.
+        basicAuth: options.basicAuth ? true : undefined,
+        customHeaders: options.headers ? Object.keys(options.headers).length : undefined,
+        storageState: options.storageState ? true : undefined,
         includePatterns: options.includePatterns,
         excludePatterns: options.excludePatterns,
-        resolutions: parsedResolutions.map((r) => `${r.width}x${r.height}`),
+        resolutions: captureTargets.map((t) => t.label),
       },
       pages: perPageResults,
       errors: errorSummaries,
@@ -1092,6 +1195,53 @@ program
   )
   .option('--wait-for-selector <css>', 'Wait for this CSS selector before capturing')
   .option('--disable-animations', 'Freeze CSS animations/transitions for stable screenshots', false)
+  .option(
+    '--scale <n>',
+    'Device scale factor / DPR (e.g. 2 for retina). Default: 1',
+    (value) => {
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        throw new Error('Scale must be a number >= 1');
+      }
+      return parsed;
+    },
+    1
+  )
+  .option<'light' | 'dark' | 'no-preference'>(
+    '--color-scheme <scheme>',
+    'Emulate prefers-color-scheme (light | dark | no-preference)',
+    (value: string) => {
+      const v = value.toLowerCase();
+      if (v !== 'light' && v !== 'dark' && v !== 'no-preference') {
+        throw new Error('Invalid color-scheme. Choose from: light, dark, no-preference');
+      }
+      return v as 'light' | 'dark' | 'no-preference';
+    }
+  )
+  .option('--user-agent <string>', 'Override the browser User-Agent string')
+  .option(
+    '--device <name>',
+    'Emulate a Playwright device (e.g. "iPhone 13"). Overrides -r and sets UA/DPR/touch.',
+    (value: string) => {
+      if (!playwright.devices[value]) {
+        throw new Error(
+          `Unknown device "${value}". See Playwright device descriptors (e.g. "iPhone 13", "Pixel 7").`
+        );
+      }
+      return value;
+    }
+  )
+  .option(
+    '--header <name:value>',
+    'Extra HTTP header to send (e.g. "Authorization: Bearer x"). Repeatable.',
+    (value: string, previous: string[] = []) => previous.concat([value]),
+    []
+  )
+  .option('--basic-auth <user:password>', 'HTTP Basic auth credentials for gated pages')
+  .option(
+    '--storage-state <file.json>',
+    'Load cookies/localStorage from a Playwright storageState file'
+  )
   .action(
     async (
       url: string,
@@ -1121,6 +1271,13 @@ program
         clip?: string;
         waitForSelector?: string;
         disableAnimations: boolean;
+        scale: number;
+        colorScheme?: 'light' | 'dark' | 'no-preference';
+        userAgent?: string;
+        device?: string;
+        header: string[];
+        basicAuth?: string;
+        storageState?: string;
       }
     ) => {
       try {
@@ -1173,6 +1330,13 @@ program
         if (mergedOptions.format !== 'jpeg' && mergedOptions.quality != null) {
           console.warn('Note: --quality only applies to --format jpeg; ignoring for png.');
         }
+        if (mergedOptions.device && userChoseResolutions) {
+          console.warn('Note: --device sets its own viewport; -r resolutions are ignored.');
+        }
+
+        const headersMap = (mergedOptions.header || []).length
+          ? parseHeaders(mergedOptions.header)
+          : undefined;
 
         // Map merged options to our interface
         const mappedOptions: CliOptions = {
@@ -1198,6 +1362,13 @@ program
           clip: mergedOptions.clip ? parseClip(mergedOptions.clip) : undefined,
           waitForSelector: mergedOptions.waitForSelector,
           disableAnimations: mergedOptions.disableAnimations,
+          scale: mergedOptions.scale,
+          colorScheme: mergedOptions.colorScheme,
+          userAgent: mergedOptions.userAgent,
+          device: mergedOptions.device,
+          headers: headersMap,
+          basicAuth: mergedOptions.basicAuth ? parseBasicAuth(mergedOptions.basicAuth) : undefined,
+          storageState: mergedOptions.storageState,
         };
 
         // Basic URL validation before passing to the main function
@@ -1242,4 +1413,6 @@ export {
   mergeConfigWithOptions,
   GetOptionSource,
   parseClip,
+  parseHeaders,
+  parseBasicAuth,
 };


### PR DESCRIPTION
## Summary

Unlocks a whole category of use cases — dark mode, real device emulation, retina, and screenshotting **gated pages** — all wired through a single `browser.newContext()`. The no-flag path stays a plain context, so existing runs are unchanged.

**Independent PR** off `main`. Carries a minor changeset.

## New options

| Option | What it does |
| --- | --- |
| `--device <name>` | Emulate a Playwright device (e.g. `"iPhone 13"`): viewport, DPR, touch, UA. Captures one shot labeled by the device; **overrides `-r`**. |
| `--color-scheme <light\|dark\|no-preference>` | Emulate `prefers-color-scheme` — **dark mode** screenshots. |
| `--scale <n>` | Device scale factor / DPR (e.g. `2` for retina). |
| `--user-agent <string>` | Override the User-Agent. |
| `--header <name:value>` (repeatable) | Extra HTTP headers (e.g. `Authorization: Bearer …`). |
| `--basic-auth <user:pass>` | HTTP Basic credentials. |
| `--storage-state <file>` | Load cookies/localStorage from a Playwright `storageState` file. |

## Secrets are never leaked
`--basic-auth`, `--header`, and `--storage-state` values are **not** printed in the banner (it shows `Auth: basic-auth; 1 custom header(s) (values hidden)`) and are recorded in `run.json` only as a boolean/count — verified.

## Verification (real CLI)
- `--scale 2 -r 800x600` → PNG is **1600×1200 px** (DPR doubled)
- `--color-scheme dark` → renders, `Emulation: color-scheme: dark`
- `--device "iPhone 13" -r 800x600` → prints the `-r ignored` note, captures one `iPhone_13-*.png`
- `--basic-auth … --header …` → no secret appears in stdout; manifest shows `basicAuth=true customHeaders=1`
- unknown `--device` → clear error listing valid examples
- `tsc` clean, **66 tests** pass (new `emulation.test.ts`), `eslint` clean.

Threaded through config merge, the run manifest, the terminal dev UI, and the dev API arg builder.

## Risk
Low — all options are opt-in; everything flows through one conditionally-built context options object, so omitting them yields exactly `browser.newContext()`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)