### PR TITLE
feat: crawl depth limit and scripting-friendly output

### DIFF
--- a/.changeset/crawl-and-output.md
+++ b/.changeset/crawl-and-output.md
@@ -1,0 +1,13 @@
+---
+'@rosbel/crawl-n-snap': minor
+---
+
+Add crawl controls and scripting-friendly output:
+
+- `--depth <n>` — bound how far a crawl follows links (in hops from the seed URL).
+- `--dry-run` — print the resolved run plan (target, output base, resolutions,
+  crawl settings) and exit without launching a browser.
+- `--json` — emit the run manifest as the only thing on stdout (human logs are
+  routed to stderr), so `crawl-n-snap … --json | jq` works.
+- `--no-color` — use plain ASCII status markers (`[OK]`/`[FAIL]`) instead of
+  unicode, for pipes and CI logs.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Options:
   --header <name:value>    Extra HTTP header to send. Repeatable.
   --basic-auth <user:pass> HTTP Basic auth credentials for gated pages
   --storage-state <file>   Load cookies/localStorage from a Playwright storageState file
+  --depth <n>              Maximum crawl depth in link hops from the seed (with --crawl). Default: unlimited
+  --dry-run                Print the resolved run plan and exit without launching a browser
+  --json                   Output the run manifest as JSON on stdout (human logs go to stderr)
+  --no-color               Disable colored/unicode status markers (plain ASCII)
   --continue-on-error      Continue processing other URLs/resolutions when errors occur (default: true)
   --fail-fast              Stop processing immediately when any error occurs
   -V, --version            Output the version number
@@ -253,6 +257,22 @@ npx @rosbel/crawl-n-snap https://example.com --storage-state ./auth.json
 ```
 
 Secrets (`--basic-auth`, `--header`, `--storage-state`) are never printed to the console or written to `run.json` (only a boolean/count is recorded).
+
+#### Crawl depth and scripting-friendly output
+
+```bash
+# Crawl only the seed page and pages it links to directly (1 hop)
+npx @rosbel/crawl-n-snap https://example.com --crawl --depth 1
+
+# Preview what a run would do without launching a browser
+npx @rosbel/crawl-n-snap https://example.com --crawl --max-pages 50 --dry-run
+
+# Machine-readable output: the manifest is the only thing on stdout
+npx @rosbel/crawl-n-snap https://example.com --json | jq '.summary'
+
+# Plain ASCII markers (e.g. when piping to a file or CI log)
+npx @rosbel/crawl-n-snap https://example.com --no-color
+```
 
 ## Output Structure
 

--- a/src/dev-server.ts
+++ b/src/dev-server.ts
@@ -140,6 +140,7 @@ function optionsToArgs(payload: any): string[] {
   (payload.headers || []).forEach((h: string) => args.push('--header', h));
   if (payload.basicAuth) args.push('--basic-auth', String(payload.basicAuth));
   if (payload.storageState) args.push('--storage-state', String(payload.storageState));
+  if (payload.depth != null) args.push('--depth', String(payload.depth));
   return args;
 }
 

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -137,6 +137,8 @@ async function main() {
     format: format as 'png' | 'jpeg',
     disableAnimations,
     scale: 1,
+    json: false,
+    color: true,
   };
 
   await runScreenshotter(url, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,9 @@ interface CliOptions {
   headers?: Record<string, string>;
   basicAuth?: {username: string; password: string};
   storageState?: string;
+  depth?: number;
+  json: boolean;
+  color: boolean;
 }
 
 interface ClipRegion {
@@ -99,6 +102,7 @@ interface ConfigFile {
   headers?: string[];
   basicAuth?: string;
   storageState?: string;
+  depth?: number;
 }
 
 // Parse a --clip value "x,y,width,height" into a region. x/y must be >= 0 and
@@ -261,6 +265,7 @@ function mergeConfigWithOptions(
     header: [...(cliOptions.header || []), ...(config.headers || [])],
     basicAuth: pick('basicAuth', cliOptions.basicAuth, config.basicAuth),
     storageState: pick('storageState', cliOptions.storageState, config.storageState),
+    depth: pick('depth', cliOptions.depth, config.depth),
   };
 }
 
@@ -501,6 +506,17 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
     throw new Error(`Invalid URL "${targetUrl}": ${error.message}`);
   }
 
+  // In --json mode, keep stdout clean for the final manifest by routing all
+  // human-readable logs to stderr. Restored in the finally block.
+  const originalConsoleLog = console.log;
+  if (options.json) {
+    console.log = (...args: any[]) => console.error(...args);
+  }
+  // Status markers: unicode when color is on, plain ASCII otherwise (pipes,
+  // CI logs, --no-color).
+  const okMark = options.color ? '✓' : '[OK]';
+  const failMark = options.color ? '✗' : '[FAIL]';
+
   // Parse string resolutions to Resolution objects
   const parsedResolutions: Resolution[] = options.resolutions.map((res) => parseResolution(res));
 
@@ -545,6 +561,7 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
   console.log(`Crawl Mode: ${options.crawl ? 'Enabled' : 'Disabled'}`);
   if (options.crawl) {
     console.log(`Max Pages: ${options.maxPages}`);
+    if (options.depth != null) console.log(`Max Depth: ${options.depth}`);
     if (options.excludePatterns.length > 0) {
       console.log(`Exclude Patterns: ${options.excludePatterns.join(', ')}`);
     }
@@ -602,9 +619,11 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
           viewport: {width: r.width, height: r.height},
         }));
 
-    // Track visited URLs to avoid loops (using normalized URLs)
+    // Track visited URLs to avoid loops (using normalized URLs). Each pending
+    // entry carries its crawl depth (the seed URL is depth 0) so --depth can
+    // bound how far link-following goes.
     const visitedUrls = new Set<string>();
-    const pendingUrls: string[] = [targetUrl];
+    const pendingUrls: Array<{url: string; depth: number}> = [{url: targetUrl, depth: 0}];
     let processedCount = 0;
     const errorSummaries: ErrorSummary[] = [];
     const runStartedAt = new Date();
@@ -652,7 +671,7 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
 
     // Process URLs until we run out or hit the limit
     while (pendingUrls.length > 0 && processedCount < options.maxPages) {
-      const currentUrl = pendingUrls.shift()!;
+      const {url: currentUrl, depth: currentDepth} = pendingUrls.shift()!;
       const normalizedUrl = normalizeUrl(currentUrl);
 
       // Skip if already visited
@@ -818,12 +837,12 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
           if (result.success) {
             const retryInfo = result.attempts > 1 ? ` (after ${result.attempts - 1} retries)` : '';
             console.log(
-              `✓ ${result.resolution} screenshot saved: ${result.outputPath}${retryInfo}`
+              `${okMark} ${result.resolution} screenshot saved: ${result.outputPath}${retryInfo}`
             );
             successCount++;
           } else {
             console.error(
-              `✗ ${result.resolution} failed after ${result.attempts} attempts: ${result.error}`
+              `${failMark} ${result.resolution} failed after ${result.attempts} attempts: ${result.error}`
             );
             failureCount++;
           }
@@ -843,8 +862,10 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
         console.log(`\nScreenshot summary: ${successCount} successful, ${failureCount} failed`);
         if (failureCount > 0) anyFailures = true;
 
-        // If crawling is enabled, extract and queue more URLs
-        if (options.crawl) {
+        // If crawling is enabled, extract and queue more URLs — unless we've
+        // reached the configured depth limit (depth is measured in link hops
+        // from the seed URL).
+        if (options.crawl && (options.depth == null || currentDepth < options.depth)) {
           // The navigation above may have returned early (before `load`), so
           // give the DOM a bounded chance to finish so links injected late are
           // still discovered. Never block past the navigation cap.
@@ -862,7 +883,7 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
               !isUrlExcluded(normalizedLink, options.excludePatterns) &&
               isUrlIncluded(normalizedLink, options.includePatterns)
             ) {
-              pendingUrls.push(normalizedLink);
+              pendingUrls.push({url: normalizedLink, depth: currentDepth + 1});
             } else if (isUrlExcluded(normalizedLink, options.excludePatterns)) {
               console.log(`  - Excluding URL (matches pattern): ${normalizedLink}`);
             } else if (!isUrlIncluded(normalizedLink, options.includePatterns)) {
@@ -930,7 +951,7 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
         console.log(`  ... and ${errorSummaries.length - 10} more errors`);
       }
     } else {
-      console.log('\n✓ No errors occurred during processing.');
+      console.log(`\n${okMark} No errors occurred during processing.`);
     }
 
     // Write run manifest
@@ -944,6 +965,7 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
         output: options.output,
         crawl: options.crawl,
         maxPages: options.maxPages,
+        depth: options.depth,
         timeout: options.timeout,
         navTimeout: options.navTimeout,
         concurrency: options.concurrency,
@@ -983,6 +1005,12 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
     await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
     console.log(`\nRun manifest written: ${manifestPath}`);
 
+    // In --json mode the manifest is the sole stdout output (human logs went to
+    // stderr), so `crawl-n-snap ... --json | jq` works.
+    if (options.json) {
+      originalConsoleLog(JSON.stringify({...manifest, manifestPath}, null, 2));
+    }
+
     if (anyFailures || errorSummaries.length > 0) {
       process.exitCode = 1;
     }
@@ -1003,6 +1031,8 @@ async function runScreenshotter(targetUrl: string, options: CliOptions) {
       await browser.close();
       console.log('Browser closed.');
     }
+    // Restore stdout logging if we redirected it for --json.
+    console.log = originalConsoleLog;
   }
 }
 
@@ -1242,6 +1272,20 @@ program
     '--storage-state <file.json>',
     'Load cookies/localStorage from a Playwright storageState file'
   )
+  .option(
+    '--depth <n>',
+    'Maximum crawl depth in link hops from the seed URL (only used with --crawl). Default: unlimited',
+    (value) => {
+      const parsed = parseInt(value, 10);
+      if (isNaN(parsed) || parsed < 0) {
+        throw new Error('Depth must be a non-negative number');
+      }
+      return parsed;
+    }
+  )
+  .option('--dry-run', 'Print the resolved run plan and exit without launching a browser', false)
+  .option('--json', 'Output the run manifest as JSON on stdout (human logs go to stderr)', false)
+  .option('--no-color', 'Disable colored/unicode status markers (use plain ASCII)')
   .action(
     async (
       url: string,
@@ -1278,6 +1322,10 @@ program
         header: string[];
         basicAuth?: string;
         storageState?: string;
+        depth?: number;
+        dryRun: boolean;
+        json: boolean;
+        color: boolean;
       }
     ) => {
       try {
@@ -1369,10 +1417,33 @@ program
           headers: headersMap,
           basicAuth: mergedOptions.basicAuth ? parseBasicAuth(mergedOptions.basicAuth) : undefined,
           storageState: mergedOptions.storageState,
+          depth: mergedOptions.depth,
+          json: options.json,
+          color: options.color,
         };
 
         // Basic URL validation before passing to the main function
         new URL(url);
+
+        // --dry-run: show the resolved plan and exit without launching a browser.
+        if (options.dryRun) {
+          const plan = {
+            target: url,
+            outputBase: path.resolve(mappedOptions.output, 'generated-screenshots'),
+            browser: mappedOptions.browser,
+            resolutions: mappedOptions.device ? [mappedOptions.device] : mappedOptions.resolutions,
+            format: mappedOptions.format,
+            crawl: mappedOptions.crawl,
+            maxPages: mappedOptions.crawl ? mappedOptions.maxPages : undefined,
+            depth: mappedOptions.crawl ? (mappedOptions.depth ?? 'unlimited') : undefined,
+            includePatterns: mappedOptions.includePatterns,
+            excludePatterns: mappedOptions.excludePatterns,
+          };
+          console.log('Dry run — no browser launched. Resolved plan:');
+          console.log(JSON.stringify(plan, null, 2));
+          return;
+        }
+
         await runScreenshotter(url, mappedOptions);
       } catch (error: any) {
         console.error(`\nError: ${error.message}`);


### PR DESCRIPTION
## Summary

Crawl controls and machine-readable output. **Independent PR** off `main`, minor changeset.

## New options

| Option | What it does |
| --- | --- |
| `--depth <n>` | Bound how far a crawl follows links (hops from the seed). The pending queue now tracks each URL's depth and stops enqueuing children past the limit. |
| `--dry-run` | Print the resolved run plan (target, output base, resolutions, crawl/maxPages/depth, patterns) and **exit without launching a browser**. |
| `--json` | Emit the run manifest as the **only** thing on stdout (human logs go to stderr), so `crawl-n-snap … --json \| jq` works. |
| `--no-color` | Plain ASCII status markers (`[OK]`/`[FAIL]`) instead of unicode — for pipes and CI logs. |

## Verification (real CLI)
- `--dry-run` → prints the plan, **no browser**, no output directory created.
- `--json` → stdout parses as JSON (`target`, `summary.pagesProcessed`, `manifestPath`); the human logs (e.g. "Launching chromium") are on **stderr**.
- `--no-color` → `[OK] … screenshot saved`.
- `--crawl --depth 0` → "Crawling complete. Processed 1 pages." (seed only, no link-following).
- `tsc` clean, **66 tests** pass, `eslint` clean.

Threaded through config merge (`depth`), the `run.json` manifest, and the dev API arg builder.

## Deferred follow-ups (noted, not in this PR)
From the audit's "crawl & output" group, intentionally left for a focused follow-up: `--sitemap` seeding, `--quiet`/`--verbose` log levels, and a TTY progress bar.

## Risk
Low — all options are opt-in; `--depth` defaults to unlimited (today's behavior), and the `--json` stdout redirect is restored in `finally`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)